### PR TITLE
PYCBC-1397: Support for Python performer

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -121,9 +121,11 @@ matrix:
     - language: Go
       version: snapshot
 
-    # Disabled as not yet checked in
-#    - language: Python
-#      version: snapshot
+    - language: Python
+      version: snapshot
+
+    - language: Python
+      version: 4.1.X
 
   workloads:
 

--- a/src/com/couchbase/perf/sdk/stages/InitialiseSDKPerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/InitialiseSDKPerformer.groovy
@@ -50,7 +50,7 @@ class InitialiseSDKPerformer extends Stage {
                 imageName = stage1.imageName
                 return produceStages(ctx, stage1, stage1.getImageName())
             } else if (impl.language == "Python"){
-                def stage1 = new BuildDockerPythonSDKPerformer(impl.version)
+                def stage1 = new BuildDockerPythonSDKPerformer(impl.version, impl.sha)
                 imageName = stage1.imageName
                 return produceStages(ctx, stage1, stage1.getImageName())
             } else{

--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -140,8 +140,8 @@ class Execute {
                     def allReleases = PythonVersions.getAllReleases()
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for Python: ${sha}")
-                    String version = highest.toString() + "-0." + sha
-                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, null))
+                    String version = highest.toString() + "-" + sha
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha))
                 }
                 else {
                     throw new UnsupportedOperationException("Cannot support snapshot builds with language ${implementation.language} yet")
@@ -153,6 +153,7 @@ class Execute {
                 else if (implementation.language == "Kotlin") implementationsToAdd.addAll(jvmVersions(ctx, implementation, "kotlin-client"))
                 else if (implementation.language == ".NET") implementationsToAdd.addAll(versions(ctx, implementation, ".NET", DotNetVersions.allReleases))
                 else if (implementation.language == "Go") implementationsToAdd.addAll(versions(ctx, implementation, "Go", GoVersions.allReleases))
+                else if (implementation.language == "Python") implementationsToAdd.addAll(versions(ctx, implementation, "Python", PythonVersions.allReleases))
                 else {
                     throw new UnsupportedOperationException("Cannot support snapshot builds with language ${implementation.language} yet")
                 }

--- a/src/com/couchbase/tools/network/NetworkUtil.groovy
+++ b/src/com/couchbase/tools/network/NetworkUtil.groovy
@@ -1,0 +1,42 @@
+package com.couchbase.tools.network
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+
+
+class NetworkUtil {
+    @CompileStatic
+    public static String read(String url, int attempts = 5) {
+        while (true) {
+            try {
+                def get = new URL(url).openConnection();
+                return get.getInputStream().getText()
+            }
+            catch (err) {
+                attempts -= 1
+                if (attempts <= 0) {
+                    throw err
+                }
+                else {
+                    System.err.println("Retrying on ${url} on error ${err} on attempt ${attempts}")
+                }
+            }
+        }
+    }
+
+    @CompileStatic
+    public static Object readJson(String url, int attempts = 5) {
+        String content = read(url, attempts)
+        def parser = new JsonSlurper()
+        return parser.parseText(content)
+    }
+
+    @CompileStatic
+    public static GPathResult readXml(String url, int attempts = 5) {
+        String content = read(url, attempts)
+        def parser = new XmlSlurper()
+        return parser.parseText(content)
+    }
+}

--- a/src/com/couchbase/tools/performer/BuildDockerPythonPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerPythonPerformer.groovy
@@ -1,0 +1,51 @@
+package com.couchbase.tools.performer
+
+import com.couchbase.context.environments.Environment
+import com.couchbase.tools.tags.TagProcessor
+import com.couchbase.versions.ImplementationVersion
+import groovy.transform.CompileStatic
+
+import java.security.cert.CertificateEncodingException
+import java.util.logging.Logger
+
+@CompileStatic
+class BuildDockerPythonPerformer {
+    /**
+     * @param path absolute path to above 'transactions-fit-performer'
+     * @param sdkVersion (e.g. '3.2.3'). If not present, it indicates to just build master.
+     */
+    private static Logger logger = Logger.getLogger("")
+
+    static void build(Environment imp, String path, Optional<String> sdkVersion, Optional<String> sha, String imageName, boolean onlySource = false) {
+        imp.dirAbsolute(path) {
+            imp.dir('transactions-fit-performer') {
+                imp.dir('performers/python') {
+                    writePythonRequirementsFile(imp, sdkVersion, sha)
+                    sdkVersion.ifPresent(v -> {
+                        TagProcessor.processTags(new File(imp.currentDir()), ImplementationVersion.from(v), false)
+                    })
+                }
+                if (!onlySource) {
+                    imp.execute("docker build -f ./performers/python/Dockerfile -t $imageName .", false, true, true)
+                }
+            }
+        }
+    }
+
+    static private void writePythonRequirementsFile(Environment imp, Optional<String> sdkVersion, Optional<String> sha) {
+        def requirements = new File("${imp.currentDir()}/cb_requirement.txt")
+        def lines = requirements.readLines()
+        requirements.write("")
+
+        for (String line : lines) {
+            if ((line.contains("couchbase") && !line.contains("/"))
+                    || line.contains("git+https://github.com/couchbase/couchbase-python-client.git")) {
+                var version = sha.orElse(sdkVersion.orElse("master"))
+                logger.info("PYCBC INSTALL FROM = git+https://github.com/couchbase/couchbase-python-client.git@${version}#egg=couchbase")
+                requirements.append("git+https://github.com/couchbase/couchbase-python-client.git@${version}#egg=couchbase\n")
+            } else {
+                requirements.append(line + "\n")
+            }
+        }
+    }
+}

--- a/src/com/couchbase/tools/performer/BuildDockerPythonPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerPythonPerformer.groovy
@@ -10,12 +10,16 @@ import java.util.logging.Logger
 
 @CompileStatic
 class BuildDockerPythonPerformer {
-    /**
-     * @param path absolute path to above 'transactions-fit-performer'
-     * @param sdkVersion (e.g. '3.2.3'). If not present, it indicates to just build master.
-     */
     private static Logger logger = Logger.getLogger("")
 
+    /**
+     * @param imp        the build environment
+     * @param path       absolute path to above 'transactions-fit-performer'
+     * @param sdkVersion (e.g. '3.2.3'). If not present (and sha is not present), it indicates to just build master.
+     * @param sha        (e.g. '20e862d'). If present, it indicates to build from specific commit
+     * @param imageName  the name of the docker image
+     * @param onlySource whether to skip the docker build
+     */
     static void build(Environment imp, String path, Optional<String> sdkVersion, Optional<String> sha, String imageName, boolean onlySource = false) {
         imp.dirAbsolute(path) {
             imp.dir('transactions-fit-performer') {

--- a/src/com/couchbase/versions/DotNetVersions.groovy
+++ b/src/com/couchbase/versions/DotNetVersions.groovy
@@ -1,28 +1,21 @@
 package com.couchbase.versions
 
-import groovy.json.JsonSlurper
+import com.couchbase.tools.network.NetworkUtil
 import groovy.transform.Memoized
 
 
 class DotNetVersions {
     @Memoized
     static String getLatestSha() {
-        String content = JVMVersions.read("https://api.github.com/repos/couchbase/couchbase-net-client/commits/master")
-        def parser = new JsonSlurper()
-        def json = parser.parseText(content)
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbase/couchbase-net-client/commits/master")
         String sha = json.sha
-
         return sha.substring(0, 6)
     }
 
     @Memoized
     static Set<ImplementationVersion> getAllReleases() {
         def out = new HashSet<ImplementationVersion>()
-
-        String url = "https://api.github.com/repos/couchbase/couchbase-net-client/tags"
-        String content = JVMVersions.read(url)
-        def parser = new JsonSlurper()
-        def json = parser.parseText(content)
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbase/couchbase-net-client/tags")
 
         for (doc in json) {
             String version = doc.name

--- a/src/com/couchbase/versions/GoVersions.groovy
+++ b/src/com/couchbase/versions/GoVersions.groovy
@@ -1,30 +1,22 @@
 package com.couchbase.versions
 
-import groovy.json.JsonSlurper
+import com.couchbase.tools.network.NetworkUtil
 import groovy.transform.Memoized
 
 
 class GoVersions {
     @Memoized
     static String getLatestSha() {
-        String content = JVMVersions.read("https://api.github.com/repos/couchbase/gocb/commits/master")
-        def parser = new JsonSlurper()
-        def json = parser.parseText(content)
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbase/gocb/commits/master")
         String sha = json.sha
         String commitDate = json.commit.committer.date
-
-
         return commitDate.replaceAll("[^0-9]", "") + "-" + sha.substring(0, 12)
     }
 
     @Memoized
     static Set<ImplementationVersion> getAllReleases() {
         def out = new HashSet<ImplementationVersion>()
-
-        String url = "https://api.github.com/repos/couchbase/gocb/tags"
-        String content = JVMVersions.read(url)
-        def parser = new JsonSlurper()
-        def json = parser.parseText(content)
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbase/gocb/tags")
 
         for (doc in json) {
             String version = doc.name

--- a/src/com/couchbase/versions/PythonVersions.groovy
+++ b/src/com/couchbase/versions/PythonVersions.groovy
@@ -1,29 +1,21 @@
 package com.couchbase.versions
 
-import groovy.json.JsonSlurper
+import com.couchbase.tools.network.NetworkUtil
 import groovy.transform.Memoized
+
 
 class PythonVersions {
     @Memoized
     static String getLatestSha() {
-        // todo under PYCBC-1397: refactor this now-shared code so it's not under JVMVersions
-        String content = JVMVersions.read("https://api.github.com/repos/couchbase/couchbase-python-client/commits/master")
-        def parser = new JsonSlurper()
-        def json = parser.parseText(content)
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbase/couchbase-python-client/commits/master")
         String sha = json.sha
-        String commitDate = json.commit.committer.date
-
-        return sha.substring(0, 6)
+        return sha.substring(0, 7)
     }
 
     @Memoized
     static Set<ImplementationVersion> getAllReleases() {
         def out = new HashSet<ImplementationVersion>()
-
-        String url = "https://api.github.com/repos/couchbase/couchbase-python-client/tags"
-        String content = JVMVersions.read(url)
-        def parser = new JsonSlurper()
-        def json = parser.parseText(content)
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbase/couchbase-python-client/tags")
 
         for (doc in json) {
             String version = doc.name
@@ -36,5 +28,9 @@ class PythonVersions {
         }
 
         return out
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Latest SHA = " + getLatestSha())
     }
 }

--- a/src/com/couchbase/versions/PythonVersions.groovy
+++ b/src/com/couchbase/versions/PythonVersions.groovy
@@ -29,8 +29,4 @@ class PythonVersions {
 
         return out
     }
-
-    public static void main(String[] args) {
-        System.out.println("Latest SHA = " + getLatestSha())
-    }
 }


### PR DESCRIPTION
* The requirements file for python performer is now edited correctly to specify a version or building from source from master or a commit SHA
* `JVMVersions.read()` moved to new class `NetworkUtil`. Added `readJson()` and `readXml()` convenience methods