### PR TITLE
Add C++ performer back in job-config and change version label for C++ snapshots

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -169,11 +169,11 @@ matrix:
     - language: Python
       version: 4.1.X
 
-#    - language: C++
-#      version: snapshot
-#
-#    - language: C++
-#      version: 1.0.0-dp.2
+    - language: C++
+      version: snapshot
+
+    - language: C++
+      version: 1.0.0-beta.4
 
     - language: Node
       version: snapshot

--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -151,10 +151,9 @@ class Execute {
                 }
                 else if (implementation.language == "C++") {
                     def sha = CppVersions.getLatestSha()
-                    def allReleases = CppVersions.getAllReleases()
-                    def highest = ImplementationVersion.highest(allReleases)
+                    // Version number is hardcoded for now - TODO: Change this when the next version is released
+                    def version = CppVersions.getLatestSnapshotLabel("1.0.0")
                     ctx.env.log("Found latest sha for C++: ${sha}")
-                    String version = highest.toString() + "-" + sha
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha))
                 }
                 else {

--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -13,6 +13,17 @@ class CppVersions {
     }
 
     @Memoized
+    static String getLatestSnapshotLabel(String version) {
+        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbaselabs/couchbase-cxx-client/commits/main")
+        String sha = json.sha
+        String commitDate = json.commit.committer.date
+        String[] parts = commitDate.split("T")
+        String date = parts[0].replaceAll("[^0-9]", "")
+        String time = parts[1].replaceAll("[^0-9]", "")
+        return version + "-" + date + "." + time + "-" + sha.substring(0, 7)
+    }
+
+    @Memoized
     static Set<ImplementationVersion> getAllReleases() {
         def out = new HashSet<ImplementationVersion>()
         def json = NetworkUtil.readJson("https://api.github.com/repos/couchbaselabs/couchbase-cxx-client/tags")


### PR DESCRIPTION
* Added C++ snapshot and beta-4 in job-config
* Changed the labels for snapshots so they look like `1.0.0-20230201.125654-1437691` (`<version>-<date>.<time>-<sha>`). Version 1.0.0 is hardcoded for now