### PR TITLE
Change the C++ snapshot build version string to be the same as the one generated by the SDK

### DIFF
--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -152,7 +152,7 @@ class Execute {
                 else if (implementation.language == "C++") {
                     def sha = CppVersions.getLatestSha()
                     // Version number is hardcoded for now - TODO: Change this when the next version is released
-                    def version = CppVersions.getLatestSnapshotLabel("1.0.0")
+                    def version = CppVersions.getLatestSnapshotLabel()
                     ctx.env.log("Found latest sha for C++: ${sha}")
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha))
                 }

--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -53,8 +53,4 @@ class CppVersions {
 
         return out
     }
-
-    public static void main(String[] args) {
-        System.out.println(getLatestSnapshotLabel());
-    }
 }


### PR DESCRIPTION
For example, for the [b3c8cbf](https://github.com/couchbaselabs/couchbase-cxx-client/commit/b3c8cbf6976c95e295005e39e0f8d7b6a8a202f9) commit the version string generated will be `1.0.0-beta.4+18.b3c8cbf`