### PR TITLE
PYCBC-1437: Use tunable to tell Python performer which concurrency mechanism to use

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -117,6 +117,11 @@ matrix:
 #      stellarNebulaSha: 945b3d0e611ddb7549453fa30b22905cb4d33a9e
 
   implementations:
+    - language: Java
+      version: 3.X.X
+
+    - language: Java
+      version: snapshot
 
     # https://review.couchbase.org/c/couchbase-jvm-clients/+/184600
     # Current head of Protostellar fork

--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -196,12 +196,6 @@ matrix:
         variables:
           - name: poolSize
             value: 10000
-          - name: concurrencyMechanism
-            type: tunable
-            value: multiprocessing
-            include:
-              - implementation:
-                  language: Python
       exclude:
         - language: Java
           version: refs/changes/59/184959/1
@@ -217,18 +211,10 @@ matrix:
             method: pool
             poolSize: $poolSize
             poolSelectionStrategy: randomUniform
-
       settings:
         variables:
           - name: poolSize
             value: 10000
-          - name: concurrencyMechanism
-            type: tunable
-            value: multiprocessing
-            include:
-              - implementation:
-                  language: Python
-
       exclude:
         - language: Java
           version: refs/changes/59/184959/1
@@ -268,12 +254,6 @@ matrix:
         variables:
           - name: docNum
             value: 10000000
-          - name: concurrencyMechanism
-            type: tunable
-            value: multiprocessing
-            include:
-              - implementation:
-                  language: Python
       exclude:
         - language: Java
           version: refs/changes/59/184959/1
@@ -324,3 +304,9 @@ settings:
     # actually supports.
     - name: api
       values: ["DEFAULT", "ASYNC"]
+    - name: concurrencyMechanism
+      type: tunable
+      value: multiprocessing
+      include:
+        - implementation:
+            language: Python

--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -117,11 +117,6 @@ matrix:
 #      stellarNebulaSha: 945b3d0e611ddb7549453fa30b22905cb4d33a9e
 
   implementations:
-    - language: Java
-      version: 3.X.X
-
-    - language: Java
-      version: snapshot
 
     # https://review.couchbase.org/c/couchbase-jvm-clients/+/184600
     # Current head of Protostellar fork
@@ -196,6 +191,12 @@ matrix:
         variables:
           - name: poolSize
             value: 10000
+          - name: concurrencyMechanism
+            type: tunable
+            value: multiprocessing
+            include:
+              - implementation:
+                  language: Python
       exclude:
         - language: Java
           version: refs/changes/59/184959/1
@@ -216,6 +217,12 @@ matrix:
         variables:
           - name: poolSize
             value: 10000
+          - name: concurrencyMechanism
+            type: tunable
+            value: multiprocessing
+            include:
+              - implementation:
+                  language: Python
 
       exclude:
         - language: Java
@@ -256,6 +263,12 @@ matrix:
         variables:
           - name: docNum
             value: 10000000
+          - name: concurrencyMechanism
+            type: tunable
+            value: multiprocessing
+            include:
+              - implementation:
+                  language: Python
       exclude:
         - language: Java
           version: refs/changes/59/184959/1

--- a/src/com/couchbase/perf/shared/config/ConfigParser.groovy
+++ b/src/com/couchbase/perf/shared/config/ConfigParser.groovy
@@ -120,9 +120,8 @@ class ConfigParser {
 
             boolean isTransactionWorkload = workload.operations.get(0).op == "transaction"
 
-            // Python runs only in ASYNC (multiprocessing) mode for performance testing
-            boolean supportsOne = !(implementation.language in ["Python"])
-            boolean supportsTwo = implementation.language in ["Java", "Python"]
+            boolean supportsOne = true
+            boolean supportsTwo = implementation.language in ["Java"]
             boolean supportsThree = implementation.language in ["Java"]
 
             // Java transactions does not have an async API
@@ -254,7 +253,8 @@ class ConfigParser {
 
             for (def inc in it.include()) {
                 if (inc.implementation() != null) {
-                    if (inc.implementation().language != implementation.language || inc.implementation().version != implementation.version) {
+                    if (inc.implementation().language != implementation.language
+                            || (inc.implementation().version != null && inc.implementation().version != implementation.version)) {
                         ret = false
                     }
                 }


### PR DESCRIPTION
* Added `concurrencyMechanism` tunable for Python in job-config.yaml
* Changed `includeVariablesThatApplyToThisRun()` to include all implementations for a language if version is not specified