### PR TITLE
CBD-5323: Follow semver spec for comparing impl versions & remove C++ snapshot version hard-coding

### DIFF
--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -148,10 +148,11 @@ class Execute {
                 }
                 else if (implementation.language == "C++") {
                     def sha = CppVersions.getLatestSha()
-                    // Version number is hardcoded for now - TODO: Change this when the next version is released
-                    def version = CppVersions.getLatestSnapshotLabel("1.0.0")
+                    def allReleases = CppVersions.getAllReleases()
+                    def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for C++: ${sha}")
-                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha, true))
+                    String version = highest.toString() + "-" + sha
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
                 }
                 else {
                     throw new UnsupportedOperationException("Cannot support snapshot builds with language ${implementation.language} yet")

--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -9,18 +9,11 @@ class CppVersions {
     static String getLatestSha() {
         def json = NetworkUtil.readJson("https://api.github.com/repos/couchbaselabs/couchbase-cxx-client/commits/main")
         String sha = json.sha
-        return sha.substring(0, 7)
-    }
-
-    @Memoized
-    static String getLatestSnapshotLabel(String version) {
-        def json = NetworkUtil.readJson("https://api.github.com/repos/couchbaselabs/couchbase-cxx-client/commits/main")
-        String sha = json.sha
         String commitDate = json.commit.committer.date
         String[] parts = commitDate.split("T")
         String date = parts[0].replaceAll("[^0-9]", "")
         String time = parts[1].replaceAll("[^0-9]", "")
-        return version + "-" + date + "." + time + "-" + sha.substring(0, 7)
+        return date + "." + time + "-" + sha.substring(0, 7)
     }
 
     @Memoized


### PR DESCRIPTION
Changes:
- Made `ImplementationVersion` implement the `Comparable` interface which makes it easier to get the max, do a sort etc.
- Defined `compareTo` by following the comparison rules on the [SemVer spec](https://semver.org/#spec-item-11) - the difference with before is that pre-release fields are also taken into account when comparing versions (could this change break any existing functionality?)
- Removed the hard-coded C++ snapshot version as it's no longer necessary now that pre-release fields are taken into account when comparing implementation versions and with the new C++ release tags
