### PR TITLE
CBD-5457: Always exclude unsupported C++ versions

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -205,13 +205,7 @@ matrix:
       version: snapshot
 
     - language: C++
-      version: 1.0.0-dp.4
-
-    - language: C++
-      version: 1.0.0-dp.5
-
-    - language: C++
-      version: 1.0.0-dp.6
+      version: 1.X.X
 
     - language: Node
       version: snapshot

--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -31,6 +31,21 @@ class CppVersions {
             }
         }
 
-        return out
+        return withoutUnsupportedVersions(out)
+    }
+
+    /**
+     * Removes the versions that are not supported by the C++ Performer. Currently the unsupported versions are
+     * all 1.0.0-beta.X releases and 1.0.0-dp.X releases where X < 4
+     */
+    private static Set<ImplementationVersion> withoutUnsupportedVersions(Set<ImplementationVersion> allVersions) {
+        return allVersions.findAll( (v) -> {
+            if (!(v.major == 1 && v.minor == 0 && v.patch == 0)) return true
+
+            String[] parts = v.snapshot.substring(1).split("\\.")
+            if (parts[0] == "dp") {
+                return Integer.parseInt(parts[1]) >= 4
+            } else return parts[0] != "beta"
+        })
     }
 }


### PR DESCRIPTION
Exclude the unsupported dp/beta C++ releases when `getAllReleases()` is called, which allows job-config to be more concise