### PR TITLE
PYCBC-1543: Fix tag processor not uncommenting indented code in Python

### DIFF
--- a/src/com/couchbase/tools/tags/TagProcessor.groovy
+++ b/src/com/couchbase/tools/tags/TagProcessor.groovy
@@ -158,7 +158,8 @@ class TagProcessor {
                                 }
 
                                 out.add(line)
-                                boolean includedAlready = isLastLine || !lines.get(i + 1).trim().startsWith(marker)
+                                // Trimming the marker for the startsWith() check because in Python it needs to have leading whitespace
+                                boolean includedAlready = isLastLine || !lines.get(i + 1).trim().startsWith(marker.trim())
                                 // logger.info("May need to modify ${file.getAbsolutePath()} ${versionRaw} include=${include} includedAlready=${includedAlready}")
                                 if (include && !includedAlready) {
                                     // Skip over the /*, e.g. don't include it in the output


### PR DESCRIPTION
The tag processor was trimming the line but not the marker, which can have leading whitespace when the code is indented in Python. This meant that `includedAlready` would never evaluate to true for indented code