### PR TITLE
Skip tag 3.4.10-rc1 for building .NET performer

### DIFF
--- a/src/com/couchbase/tools/performer/BuildPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildPerformer.groovy
@@ -117,8 +117,9 @@ class BuildPerformer {
                 case Sdk.DOTNET:
                     // 3.3.0 is earliest supported
                     def target = ImplementationVersion.from("3.3.0")
+                    def skipVersion = new ImplementationVersion(3, 4, 10, "rc1")
                     def vers = DotNetVersions.allReleases
-                            .findAll { it.isAbove(target) || it.equals(target) }
+                            .findAll { it.isAbove(target) || it.equals(target) && !it.equals(skipVersion)}
                     def implementation = new PerfConfig.Implementation(".NET", "3.X.0", null)
                     versions = Versions.versions(env, implementation, ".NET", vers)
                     break


### PR DESCRIPTION
Motivation
----------
A misnamed tag is causing issues when building the .NET performer after running the tag-preprocessor.

Changes
-------
Added a "skipVersion" to the DOTNET case in BuildPerformer.