### PR TITLE
Support BuildMain in BuildDockerGoPerformer

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -190,6 +190,9 @@ matrix:
       version: 2.6.X
 
     - language: Go
+      version: 2.7.X
+
+    - language: Go
       version: snapshot
 
     - language: Python


### PR DESCRIPTION
Currently the option to build main was ignored, which meant that the Go SDK version specified in the committed go.mod file was used instead of the latest commit on master. Will add a new `SDK_VERSION` build parameter to the Go Dockerfile to support this