### PR TITLE
Fix formatting of C++ snapshot versions

### DIFF
--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -107,7 +107,7 @@ class Execute {
                     def allReleases = PythonVersions.getAllReleases()
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for Python: ${sha}")
-                    String version = highest.toString() + "-" + sha
+                    String version = PythonVersions.formatSnapshotVersion(highest, sha)
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
                 }
                 else if (implementation.language == "Node") {
@@ -131,7 +131,7 @@ class Execute {
                     def allReleases = RubyVersions.getAllReleases()
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for Ruby: ${sha}")
-                    String version = highest.toString() + "-" + sha
+                    String version = RubyVersions.formatSnapshotVersion(highest, sha)
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
                 }
                 else {

--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -123,7 +123,7 @@ class Execute {
                     def allReleases = CppVersions.getAllReleases()
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for C++: ${sha}")
-                    String version = highest.toString() + "-" + sha
+                    String version = CppVersions.formatSnapshotVersion(highest, sha)
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
                 }
                 else if (implementation.language == "Ruby") {

--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -19,6 +19,10 @@ class CppVersions {
         return withoutUnsupportedVersions(out)
     }
 
+    static String formatSnapshotVersion(ImplementationVersion version, String sha) {
+        return Versions.appendPreReleaseIdentifierToVersion(version.toString(), sha)
+    }
+
     /**
      * Removes the versions that are not supported by the C++ Performer. Currently the unsupported versions are
      * all 1.0.0-beta.X releases and 1.0.0-dp.X releases where X < 10

--- a/src/com/couchbase/versions/GithubVersions.groovy
+++ b/src/com/couchbase/versions/GithubVersions.groovy
@@ -27,7 +27,8 @@ class GithubVersions {
         String time = parts[1].replaceAll("[^0-9]", "")
         // Why 7 characters here but 6 characters in getLatestSha?  Because it was in the code that's being refactored
         // here.  It's probably not strictly necessary, but keeping it so the SDK Performance results remain consistent.
-        return date + "." + time + "-" + sha.substring(0, 7)
+        // Use '+' to append the SHA, to treat it as build metadata that's ignored in semver sorting.
+        return date + "." + time + "+" + sha.substring(0, 7)
     }
 
     static String parseLinkHeaderForNext(URLConnection connection) {

--- a/src/com/couchbase/versions/PythonVersions.groovy
+++ b/src/com/couchbase/versions/PythonVersions.groovy
@@ -17,4 +17,8 @@ class PythonVersions {
     static Set<ImplementationVersion> getAllReleases() {
         return GithubVersions.getAllReleases(REPO)
     }
+
+    static String formatSnapshotVersion(ImplementationVersion version, String sha) {
+        return Versions.appendPreReleaseIdentifierToVersion(version.toString(), sha)
+    }
 }

--- a/src/com/couchbase/versions/RubyVersions.groovy
+++ b/src/com/couchbase/versions/RubyVersions.groovy
@@ -17,4 +17,8 @@ class RubyVersions {
     static Set<ImplementationVersion> getAllReleases() {
         return GithubVersions.getAllReleases(REPO)
     }
+
+    static String formatSnapshotVersion(ImplementationVersion version, String sha) {
+        return Versions.appendPreReleaseIdentifierToVersion(version.toString(), sha)
+    }
 }

--- a/src/com/couchbase/versions/Versions.groovy
+++ b/src/com/couchbase/versions/Versions.groovy
@@ -43,4 +43,13 @@ class Versions {
         def allVersions = JVMVersions.getAllJVMReleases(client)
         return versions(env, implementation, client, allVersions)
     }
+
+    static String appendPreReleaseIdentifierToVersion(String version, String identifier)
+    {
+        if (version.contains('-')) {
+            return version + "." + identifier
+        } else {
+            return version + "-" + identifier
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

Currently snapshot labels for C++ are formatted as (for example) `1.0.0-dp.13-20240306.194113-7ee5a53`. According to semver, anything after the first `-` is treated as a set of dot separated identifiers which are compared to sort versions. This means that `13-20240306` is one of those identifiers. As it contains a non-numeric character (`-`), this identifier is being compared lexically based on ASCII order which results in incorrect ordering for the C++ perf results.

## Changes

* If the fetched latest version is already a pre-release version (e.g. `dp` or `rc`), append any additional pre-release identifiers using `.` instead of `-` to ensure that the date forms its own identifier.
* Use `+` instead of `-` to append the commit SHA. This ensures that it is treated as build metadata not used for ordering.

With both of these changes, the above becomes: `1.0.0-dp.13.20240306.194113+7ee5a53`. And for a non-dp version this would be `1.1.2-20240306.194113+7ee5a53`