### PR TITLE
Fix Node HasVersion build

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerNodePerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerNodePerformer.groovy
@@ -44,7 +44,7 @@ class BuildDockerNodePerformer {
                 } else if (build instanceof HasSha) {
                     shaFile.append(build.sha())
                 } else if (build instanceof HasVersion) {
-                    packageFile.append("\t\"couchbase\": \"^${build.version()}\",\n")
+                    packageFile.append("\t\"couchbase\": \"${build.version()}\",\n")
                 } else {
                     packageFile.append(line + "\n")
                 }


### PR DESCRIPTION
We're currently appending `^` at the start of the specified build version, which allows npm to install the latest minor/patch of the specified SDK version. This change forces npm to install the exact SDK version specified.