### PR TITLE
Remove submodule update

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
@@ -17,7 +17,7 @@ class BuildDockerDotNetPerformer {
         // Build context needs to be perf-sdk as we need the .proto files
         imp.dirAbsolute(path) {
             imp.dir('transactions-fit-performer') {
-                imp.execute('git submodule update --init --recursive', false, false, true)
+                //No need to use the submodule as the Dockerfile deletes it and runs a fresh clone
                 imp.dir('performers/dotnet') {
                     // couchbase-net-client is a git submodule
                     TagProcessor.processTags(new File(imp.currentDir()), build)


### PR DESCRIPTION
Motivation
----------
In order to run the validation jenkins job with certain SDKs, the .git folder has to be removed. This prevents cloning the submodule for couchbase-net-client, however the Dockerfile for building the performer has now been modified to perform a fresh clone of the SDK instead of using the submodule.