### PR TITLE
Add option to set docker build arguments via `buildPerformer` command

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerCppPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerCppPerformer.groovy
@@ -18,7 +18,7 @@ class BuildDockerCppPerformer {
      * @param imageName  the name of the docker image
      * @param onlySource whether to skip the docker build
      */
-    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false) {
+    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false, Map<String, String> dockerBuildArgs = [:]) {
         imp.log("Building C++ ${build}")
 
         if (build instanceof BuildGerrit) {
@@ -30,9 +30,12 @@ class BuildDockerCppPerformer {
                 imp.dir('performers/cpp') {
                     TagProcessor.processTags(new File(imp.currentDir()), build)
                 }
+
+                def serializedBuildArgs = dockerBuildArgs.collect((k, v) -> "--build-arg $k=$v").join(" ")
+
                 if (!onlySource) {
                     String branch = getSdkBranch(build)
-                    String cmd = "docker build -f ./performers/cpp/Dockerfile -t $imageName --build-arg SDK_BRANCH=$branch  ."
+                    String cmd = "docker build -f ./performers/cpp/Dockerfile -t $imageName --build-arg SDK_BRANCH=$branch $serializedBuildArgs ."
                     imp.execute(cmd, false, true, true)
                 }
             }

--- a/src/com/couchbase/tools/performer/BuildDockerPythonPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerPythonPerformer.groovy
@@ -19,7 +19,7 @@ class BuildDockerPythonPerformer {
      * @param imageName  the name of the docker image
      * @param onlySource whether to skip the docker build
      */
-    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false) {
+    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false, Map<String, String> dockerBuildArgs = [:]) {
         imp.log("Building Python ${build}")
 
         if (build instanceof BuildGerrit) {
@@ -32,8 +32,11 @@ class BuildDockerPythonPerformer {
                     writePythonRequirementsFile(imp, build)
                     TagProcessor.processTags(new File(imp.currentDir()), build)
                 }
+
+                def serializedBuildArgs = dockerBuildArgs.collect((k, v) -> "--build-arg $k=$v").join(" ")
+
                 if (!onlySource) {
-                    imp.execute("docker build -f ./performers/python/Dockerfile -t $imageName .", false, true, true)
+                    imp.execute("docker build -f ./performers/python/Dockerfile -t $imageName $serializedBuildArgs .", false, true, true)
                 }
             }
         }

--- a/src/com/couchbase/tools/performer/BuildDockerRubyPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerRubyPerformer.groovy
@@ -16,7 +16,7 @@ class BuildDockerRubyPerformer {
      * @param imageName  the name of the docker image
      * @param onlySource whether to skip the docker build
      */
-    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false) {
+    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false, Map<String, String> dockerBuildArgs = [:]) {
         imp.log("Building Ruby ${build}")
 
         if (build instanceof BuildGerrit) {
@@ -29,19 +29,21 @@ class BuildDockerRubyPerformer {
                     TagProcessor.processTags(new File(imp.currentDir()), build)
                 }
 
-                def buildArgs = "SDK_BRANCH=main"
+                def buildArgs = "--build-arg SDK_BRANCH=main"
                 def dockerfile = "snapshot.Dockerfile"
 
 
                 if (build instanceof HasSha) {
-                    buildArgs = "SDK_REF=${build.sha()}"
+                    buildArgs = "--build-arg SDK_REF=${build.sha()}"
                 } else if (build instanceof HasVersion) {
-                    buildArgs = "SDK_VERSION=${build.version()}"
+                    buildArgs = "--build-arg SDK_VERSION=${build.version()}"
                     dockerfile = "release.Dockerfile"
                 }
 
+                buildArgs += " " + dockerBuildArgs.collect((k, v) -> "--build-arg $k=$v").join(" ")
+
                 if (!onlySource) {
-                    imp.execute("docker build -f performers/ruby/dockerfiles/$dockerfile --build-arg $buildArgs -t $imageName .", false, true, true)
+                    imp.execute("docker build -f performers/ruby/dockerfiles/$dockerfile $buildArgs -t $imageName .", false, true, true)
                 }
             }
         }


### PR DESCRIPTION
Adds the `--docker-build-args` option which takes space separated build args, e.g. `ARG1=foo ARG2=bar`. Currently enabled for C++, Python, Ruby.