### PR TITLE
Supported nested tags and if/else

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ See https://github.com/couchbaselabs/transactions-fit-performer/blob/master/perf
 # CLI tools
 
 ## Tags
-See the comments on `TagProcessor` for more.
+A pre-processor conditionally comments-out bits of code depending on a target SDK version.
+The pre-processor directives are referred to as "tags". See the [Tag Syntax Guide](TAG_SYNTAX.md).
+
+To run `TagProcessor` from the command line using Gradle:
 ```
 ./gradlew tags --args="-d <some_path> -v 3.0.0"
 ```
 
-To restore the code use the -r flag:
+To restore the code to its "pre-preprocessed" state, use the -r flag:
 ```
 ./gradlew tags --args="-d <some_path> -v 3.0.0 -r"
 ```

--- a/TAG_SYNTAX.md
+++ b/TAG_SYNTAX.md
@@ -1,0 +1,112 @@
+# Tag Syntax
+
+An example from the Java performer, where an expiry() overload was added in version 3.0.7:
+```
+// [if:3.0.7]
+out.expiry(Instant.ofEpochSecond(opts.getExpiry().getAbsoluteEpochSecs()));
+// [else]
+throw new UnsupportedOperationException(
+    "This SDK version does not support absolute expiry"
+);
+// [end]
+```
+
+The `else` clause is optional, so this is also valid:
+```
+// [if:3.0.7]
+somethingThatRequiresThisVersion();
+// [end]
+```
+
+## Version comparison operators
+
+The default version comparison operator is "greater than or equal to".
+You can also do a "less than" comparison:
+```
+// [if:<3.0.7]
+somethingForEarlierVersions();
+// [end]
+```
+
+## Version ranges
+
+You can "and" two conditions to express a version range:
+```
+// [if:3.0.7&&<3.1.0]
+somethingThatRequiresThisVersionRange()
+// [end]
+```
+
+## Nested tags
+
+Tags may be nested.
+The above tag with a compound condition is equivalent to the nested tags:
+```
+// [if:3.0.7]
+// [if:<3.1.0]
+someCodeThatRequiresThisVersionRange()
+// [end]
+// [end]
+```
+
+## Tag descriptions
+
+The tag processor ignores any text on the same line as an `if`, `else`, or `end` tag. 
+You can take advantage of this to annotate your tags with a human-readable description.
+For example:
+```
+// [if:3.0.7] everything after the "]" is ignored by the tag processor
+```
+
+## Conditional comments
+
+Sometimes it's not possible for both `if/else` branches to co-exist in the unprocessed source code.
+For example, in Java it is not possible to have two return statements one after the other.
+In that case, you can use the special comment prefix `//?` (or `#?` for Python and Ruby) to express code that is commented-out by default, but should be un-commented when its enclosing condition is satisfied.
+
+Here's an example where a function's return value depends on the SDK version:
+
+```
+// [if:1.2.3]
+return new Foo();
+// [else]
+//? return null;
+// [end]
+```
+
+In that example, if the SDK version is >= `1.2.3` the preprocessor doesn't change the behavior of this code.
+If the SDK version is < `1.2.3` the preprocessor comments out `return new Foo();` and un-comments `return null;` 
+
+Conditional comments may be used inside `if` and `else` tags.
+It is a syntax error for a conditional comment to appear anywhere else.
+
+## Skipping the rest of a file
+
+Use a `skip` tag to conditionally skip all subsequent lines in a file.
+If the condition is met, this bypasses all subsequent tag processing in the file.
+```
+// [skip:<3.1.0]
+```
+
+## Compatibility notes
+
+There are two versions of the tag processor syntax: version 0 and version 1.
+These versions use different strategies to comment out code.
+If a codebase assumes the tag processor inserts multi-line comment markers, it's probably not compatible with version 1.
+
+To opt in to version 1 for a particular source file, use at least one `if` tag in that file.
+
+### Version 1
+
+* Supports `if`, `else`, `end`, and `skip` tags.
+* Allows `start` as an alias for `if`.
+* Supports nested tags.
+* Supports conditional comments (`//?`) inside `if/else` blocks.
+* Uses single-line comment markers (eg. `//`, `#`) to comment out code.
+
+### Version 0
+
+* Supports `start`, `end`, and `skip` tags.
+* Requires specifying a condition for end tags.
+* Does not support nested tags.
+* Uses multi-line comment markers (eg. `/*`, `*/`) to comment out code.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 plugins {
     id 'groovy'
     id 'java-library'
- }
+}
 
 java {
     toolchain {
@@ -43,7 +43,16 @@ sourceSets {
             srcDirs 'vars'
         }
     }
- }
+    test {
+        groovy {
+            srcDirs 'test/src'
+        }
+    }
+}
+
+test {
+    useJUnitPlatform()
+}
 
 dependencies {
     implementation 'org.apache.groovy:groovy-all:4.0.4'
@@ -51,7 +60,8 @@ dependencies {
     implementation 'org.yaml:snakeyaml:1.30'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.3'
     implementation 'org.postgresql:postgresql:42.3.6'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
 }
 
 

--- a/src/com/couchbase/tools/tags/TagProcessor.groovy
+++ b/src/com/couchbase/tools/tags/TagProcessor.groovy
@@ -1,85 +1,68 @@
 package com.couchbase.tools.tags
 
-import com.couchbase.tools.performer.BuildGerrit
-import com.couchbase.tools.performer.BuildMain
-import com.couchbase.tools.performer.BuildSha
-import com.couchbase.tools.performer.BuildVersion
-import com.couchbase.tools.performer.HasVersion
-import com.couchbase.tools.performer.VersionToBuild
+import com.couchbase.tools.performer.*
 import com.couchbase.versions.ImplementationVersion
 import groovy.cli.picocli.CliBuilder
+import groovy.io.FileType
 import groovy.transform.CompileStatic
 
+import java.nio.file.Files
 import java.util.logging.ConsoleHandler
 import java.util.logging.LogRecord
 import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
+import java.util.regex.Pattern
 
 /**
- * We need to build the performers against a wide range of SDKs.  It's possible to handle some of this with reflection,
- * but not in all languages, and it gets messy.
- *
- * So, we now support a tagging system, allowing blocks of code to be commented or not, based on the SDK version being
- * compiled.
- *
- * An example from the Java performer, where an expiry() overload was added in version 3.0.7:
- *
- * // [start:3.0.7]
- * out.expiry(Instant.ofEpochSecond(opts.getExpiry().getAbsoluteEpochSecs()));
- * // [end:3.0.7]
- * // [start:<3.0.7]
- * throw new UnsupportedOperationException("This SDK version does not support this form of expiry");
- * // [end:<3.0.7]
- *
- * So "3.0.7" should be read as ">=3.0.7"
- *
- * Other supported syntax:
- * // [start:3.0.7&&<3.1.0]
- * // [end:3.0.7&&<3.1.0]
- *
- * // [skip:<3.1.0]
- *
- * It's important to understand that the parser is _very_ dumb.  It doesn't track state, it doesn't know it's inside a
- * [start] block, it can't handle nesting.  It just inserts comment markers on or immediately after the tag.
- *
- * This tool is available in CLI form so it can also be used by the FIT CI jobs.
+ * A pre-processor that comments-out bits of code depending on a target SDK version.
+ * <p>
+ * See TAG_SYNTAX.md for more info.
+ * <p>
+ * See README.md for an example of how to run this from the command line using Gradle.
  */
 class TagProcessor {
     private static Logger logger = Logger.getLogger("")
 
-    @CompileStatic
-    static boolean match(String s, ImplementationVersion sdkVersion) {
-        boolean isLessThan = s.contains("<")
-        String versionRaw
-        if (isLessThan) {
-            versionRaw = s.split("<")[1].split("]")[0]
-        } else {
-            versionRaw = s.split(":")[1].split("]")[0]
-        }
-        def version = ImplementationVersion.from(versionRaw)
-        return (isLessThan ? (sdkVersion.isBelow(version)) : (sdkVersion.isAbove(version) || sdkVersion == version))
+    static boolean hasIfTags(File file) {
+        String commentPrefix = file.name.endsWithAny(".rb", ".py") ? "#" : "//";
+        String content = Files.readString(file.toPath())
+        return content =~ /(?m).*${Pattern.quote(commentPrefix)}\s*\[if:.+]/
     }
 
     @CompileStatic
-    static boolean isMatch(String line, VersionToBuild build) {
-        if (build instanceof BuildMain) return false
+    public static void processTags(File rootDirectory, ImplementationVersion version) {
+        def warnings = new ArrayList()
 
-        ImplementationVersion sdkVersion = (build as HasVersion).implementationVersion() as ImplementationVersion
-
-        if (line.contains("&&")) {
-            var split = line.split("&&")
-            return match(split[0], sdkVersion) && match(split[1], sdkVersion)
+        rootDirectory.traverse(type: FileType.FILES) { file ->
+            // Let developers opt in to the single-line comment implementation
+            if (hasIfTags(file)) {
+                logger.info("Processing any tags in file ${file.getAbsolutePath()} using V1 ('if', 'else', nested tags)")
+                warnings.addAll(TagProcessorV1.process(file, version))
+            } else {
+                logger.info("Processing any tags in file ${file.getAbsolutePath()} using V0 (no 'if' or nested tags)")
+                TagProcessorV0.processTags(file, new BuildVersion(version.toString()))
+            }
         }
 
-        return match(line, sdkVersion)
+        warnings.forEach(it -> logger.warning(it.toString()))
+    }
+
+    static void restoreAll(File rootDirectory, String version) {
+        rootDirectory.traverse(type: FileType.FILES) { file ->
+            if (hasIfTags(file)) {
+                TagProcessorV1.restoreFile(file)
+            } else {
+                TagProcessorV0.processTags(file, new BuildVersion(version), true)
+            }
+        }
     }
 
     /**
-     * @param curPath    a directory to recursively run the tags processing on all files below
-     * @param build      what to build
+     * @param rootDirectory a directory to recursively run the tags processing on all files below
+     * @param build what to build
      */
     @CompileStatic
-    public static void processTags(File curPath, VersionToBuild build, boolean restoreMode = false) {
+    public static void processTags(File rootDirectory, VersionToBuild build) {
         // See comments on these two classes for why tags processing is skipped in these modes.
         if (build instanceof BuildGerrit || build instanceof BuildSha) {
             return
@@ -93,105 +76,8 @@ class TagProcessor {
             return
         }
 
-        curPath.listFiles().each { File file ->
-
-            if (file.isFile()) {
-                logger.info("Processing any tags in file ${file.getAbsolutePath()}")
-
-                boolean isPython = file.toString().endsWith(".py")
-                boolean isRuby = file.toString().endsWith(".rb")
-
-                var commentMarker = "//"
-                if (isPython || isRuby) {
-                    commentMarker = "#"
-                }
-
-                var out = new ArrayList<>()
-                var lines = file.readLines()
-                boolean needsOverwriting = false
-                boolean skipMode = false
-
-                for (int i = 0; i < lines.size(); i++) {
-                    var line = lines.get(i)
-                    boolean isStart = line.contains(commentMarker + " [start:")
-                    boolean isEnd = line.contains(commentMarker + " [end:")
-                    boolean isSkip = line.contains(commentMarker + " [skip:")
-                    boolean isSkipped = line.startsWith(commentMarker + " [skipped]")
-
-                    if (skipMode) {
-                        needsOverwriting = true
-                        if (!isSkipped) {
-                            out.add(commentMarker + " [skipped] " + line)
-                        } else {
-                            // Line is already skipped, can just add it
-                            out.add(line)
-                        }
-                    } else {
-                        if (isSkipped) {
-                            // Remove "// [skipped]
-                            line = line.substring(commentMarker.length() + 10)
-                            needsOverwriting = true
-                        }
-
-                        if (isStart || isEnd || isSkip) {
-                            boolean isLastLine = i == lines.size() - 1
-                            boolean match = isMatch(line, build)
-
-                            if (isStart || isEnd) {
-                                boolean include = restoreMode || match
-                                String marker
-                                if (isPython) {
-                                    var leadingWhitespaceLength = line.length() - line.stripLeading().length()
-                                    marker = " ".repeat(leadingWhitespaceLength) + "'''"
-                                } else if (isRuby) {
-                                    if (isStart) {
-                                        marker = "=begin"
-                                    } else {
-                                        marker = "=end"
-                                    }
-                                } else {
-                                    if (isStart) {
-                                        marker = "/*"
-                                    } else {
-                                        marker = "*/"
-                                    }
-                                }
-
-                                out.add(line)
-                                // Trimming the marker for the startsWith() check because in Python it needs to have leading whitespace
-                                boolean includedAlready = isLastLine || !lines.get(i + 1).trim().startsWith(marker.trim())
-                                // logger.info("May need to modify ${file.getAbsolutePath()} ${versionRaw} include=${include} includedAlready=${includedAlready}")
-                                if (include && !includedAlready) {
-                                    // Skip over the /*, e.g. don't include it in the output
-                                    needsOverwriting = true
-                                    i += 1
-                                }
-                                if (!include && includedAlready) {
-                                    needsOverwriting = true
-                                    out.add(marker)
-                                }
-                            } else { // isSkip
-                                skipMode = !restoreMode && match
-                                out.add(line)
-                            }
-                        } else {
-                            out.add(line)
-                        }
-                    }
-                }
-
-                if (needsOverwriting) {
-                    boolean fileEndedWithNewLine = lines.get(lines.size() - 1).isBlank()
-                    // logger.info("Modifying file ${file.getAbsolutePath()}")
-                    def w = file.newWriter()
-                    w << out.join(System.lineSeparator()) + (fileEndedWithNewLine ? System.getProperty("line.separator") : "")
-                    w.close()
-
-                }
-            } else {
-                processTags(file, build)
-            }
-        }
+        def version = ImplementationVersion.from(((HasVersion) build).version())
+        processTags(rootDirectory, version)
     }
 
     static void configureLogging(Logger logger) {
@@ -227,11 +113,15 @@ class TagProcessor {
             System.exit(-1)
         }
 
-        if (options.v) {
-            processTags(new File(options.d), new BuildVersion(options.v), options.r)
+        if (options.r) {
+            restoreAll(new File(options.d), options.v)
+            return
         }
-        else {
-            processTags(new File(options.d), new BuildMain(), options.r)
+
+        if (options.v) {
+            processTags(new File(options.d), new BuildVersion(options.v))
+        } else {
+            processTags(new File(options.d), new BuildMain())
         }
     }
 }

--- a/src/com/couchbase/tools/tags/TagProcessorV0.groovy
+++ b/src/com/couchbase/tools/tags/TagProcessorV0.groovy
@@ -1,0 +1,144 @@
+package com.couchbase.tools.tags
+
+import com.couchbase.tools.performer.*
+import com.couchbase.versions.ImplementationVersion
+import groovy.transform.CompileStatic
+
+class TagProcessorV0 {
+
+    @CompileStatic
+    static boolean match(String s, ImplementationVersion sdkVersion) {
+        boolean isLessThan = s.contains("<")
+        String versionRaw
+        if (isLessThan) {
+            versionRaw = s.split("<")[1].split("]")[0]
+        } else {
+            versionRaw = s.split(":")[1].split("]")[0]
+        }
+        def version = ImplementationVersion.from(versionRaw)
+        return (isLessThan ? (sdkVersion.isBelow(version)) : (sdkVersion.isAbove(version) || sdkVersion == version))
+    }
+
+    @CompileStatic
+    static boolean isMatch(String line, VersionToBuild build) {
+        if (build instanceof BuildMain) return false
+
+        ImplementationVersion sdkVersion = (build as HasVersion).implementationVersion() as ImplementationVersion
+
+        if (line.contains("&&")) {
+            var split = line.split("&&")
+            return match(split[0], sdkVersion) && match(split[1], sdkVersion)
+        }
+
+        return match(line, sdkVersion)
+    }
+
+
+    @CompileStatic
+    public static void processTags(File file, VersionToBuild build, boolean restoreMode = false) {
+        // See comments on these two classes for why tags processing is skipped in these modes.
+        if (build instanceof BuildGerrit || build instanceof BuildSha) {
+            return
+        }
+
+        // If building main there's nothing to do, since we don't know what version we're building.
+        // Note that if the source is currently set into e.g. 3.4.3 mode, then what we really want to do is to reset
+        // the code to 'main'.  So there is a bug here, as that's not done anywhere.  But it's unlikely to be a bug
+        // that impacts anyone: the functional tests only build master, and the perf tests only build specific versions or shas.
+        if (build instanceof BuildMain) {
+            return
+        }
+
+
+        boolean isPython = file.toString().endsWith(".py")
+        boolean isRuby = file.toString().endsWith(".rb")
+
+        var commentMarker = "//"
+        if (isPython || isRuby) {
+            commentMarker = "#"
+        }
+
+        var out = new ArrayList<>()
+        var lines = file.readLines()
+        boolean needsOverwriting = false
+        boolean skipMode = false
+
+        for (int i = 0; i < lines.size(); i++) {
+            var line = lines.get(i)
+            boolean isStart = line.contains(commentMarker + " [start:")
+            boolean isEnd = line.contains(commentMarker + " [end:")
+            boolean isSkip = line.contains(commentMarker + " [skip:")
+            boolean isSkipped = line.startsWith(commentMarker + " [skipped]")
+
+            if (skipMode) {
+                needsOverwriting = true
+                if (!isSkipped) {
+                    out.add(commentMarker + " [skipped] " + line)
+                } else {
+                    // Line is already skipped, can just add it
+                    out.add(line)
+                }
+            } else {
+                if (isSkipped) {
+                    // Remove "// [skipped]
+                    line = line.substring(commentMarker.length() + 10)
+                    needsOverwriting = true
+                }
+
+                if (isStart || isEnd || isSkip) {
+                    boolean isLastLine = i == lines.size() - 1
+                    boolean match = isMatch(line, build)
+
+                    if (isStart || isEnd) {
+                        boolean include = restoreMode || match
+                        String marker
+                        if (isPython) {
+                            var leadingWhitespaceLength = line.length() - line.stripLeading().length()
+                            marker = " ".repeat(leadingWhitespaceLength) + "'''"
+                        } else if (isRuby) {
+                            if (isStart) {
+                                marker = "=begin"
+                            } else {
+                                marker = "=end"
+                            }
+                        } else {
+                            if (isStart) {
+                                marker = "/*"
+                            } else {
+                                marker = "*/"
+                            }
+                        }
+
+                        out.add(line)
+                        // Trimming the marker for the startsWith() check because in Python it needs to have leading whitespace
+                        boolean includedAlready = isLastLine || !lines.get(i + 1).trim().startsWith(marker.trim())
+                        // logger.info("May need to modify ${file.getAbsolutePath()} ${versionRaw} include=${include} includedAlready=${includedAlready}")
+                        if (include && !includedAlready) {
+                            // Skip over the /*, e.g. don't include it in the output
+                            needsOverwriting = true
+                            i += 1
+                        }
+                        if (!include && includedAlready) {
+                            needsOverwriting = true
+                            out.add(marker)
+                        }
+                    } else { // isSkip
+                        skipMode = !restoreMode && match
+                        out.add(line)
+                    }
+                } else {
+                    out.add(line)
+                }
+            }
+        }
+
+        if (needsOverwriting) {
+            boolean fileEndedWithNewLine = lines.get(lines.size() - 1).isBlank()
+            // logger.info("Modifying file ${file.getAbsolutePath()}")
+            def w = file.newWriter()
+            w << out.join(System.lineSeparator()) + (fileEndedWithNewLine ? System.getProperty("line.separator") : "")
+            w.close()
+
+        }
+    }
+}

--- a/src/com/couchbase/tools/tags/TagProcessorV1.groovy
+++ b/src/com/couchbase/tools/tags/TagProcessorV1.groovy
@@ -1,0 +1,307 @@
+package com.couchbase.tools.tags
+
+import com.couchbase.versions.ImplementationVersion
+import groovy.transform.ImmutableOptions
+
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.function.BiFunction
+import java.util.function.Predicate
+import java.util.regex.Pattern
+
+import static java.util.Objects.requireNonNull
+
+/**
+ * Supports if/else and nested tags.
+ */
+class TagProcessorV1 {
+    private final File file
+    private final String commentPrefix
+    private final String conditionalCommentPrefix
+    private final String original
+
+    // Gets appended to a line to indicate it was originally a conditional comment ("//?" or "#?")
+    private final String activationMarker
+
+    private TagProcessorV1(File file) {
+        this.file = file
+        this.original = Files.readString(file.toPath())
+        this.commentPrefix = file.name.endsWithAny(".rb", ".py") ? "#" : "//"
+        this.conditionalCommentPrefix = commentPrefix + "?"
+        this.activationMarker = " " + commentPrefix + " [ACTIVATED]"
+    }
+
+    static List<String> process(File f, ImplementationVersion version) {
+        return new TagProcessorV1(f).processTags(version)
+    }
+
+    String addDeactivatedPrefix(String s) {
+        return commentPrefix + " [DEACTIVATED]" + s
+    }
+
+    static void restoreFile(File file) {
+        TagProcessorV1 strategy = new TagProcessorV1(file)
+        String restored = strategy.restore()
+
+        if (strategy.original != restored) {
+            atomicWrite(file, restored)
+        }
+    }
+
+    String restore() {
+        String undeactivated = original.replaceAll("(?m)^" + Pattern.quote(commentPrefix + " [DEACTIVATED]"), "")
+
+        def list = new ArrayList()
+        undeactivated.eachLine { line -> list.add(restoreActivatedCode(line)) }
+        return join(list)
+    }
+
+    String join(List<String> lines) {
+        def result = lines.join(System.lineSeparator())
+        if (original.endsWith(System.lineSeparator())) {
+            result += System.lineSeparator()
+        }
+        return result
+    }
+
+    static void atomicWrite(File file, String content) {
+        File temp = new File(file.parentFile, file.name + ".tag_processor_temp")
+        try {
+            Files.writeString(temp.toPath(), content)
+            Files.move(temp.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            temp.delete()
+        }
+    }
+
+    String activateCode(String line) {
+        def prefixStart = line.indexOf(conditionalCommentPrefix)
+        def prefixEnd = prefixStart + conditionalCommentPrefix.length()
+        return line.substring(0, prefixStart) + line.substring(prefixEnd).stripLeading() + activationMarker
+    }
+
+    String restoreActivatedCode(String line) {
+        if (!line.endsWith(activationMarker)) return line
+
+        def indexOfNonWhitespace = line.findIndexOf { !Character.isWhitespace(it.charAt(0)) }
+
+        // put back the conditional comment prefix at the start of the line
+        line = line.substring(0, indexOfNonWhitespace) + conditionalCommentPrefix + " " + line.stripLeading()
+
+        // remove the activation marker from the end of the line
+        line = line.substring(0, line.length() - activationMarker.length())
+
+        return line
+    }
+
+    enum Operator {
+        GTE(">=", (left, right) -> left >= right),
+        LT("<", (left, right) -> left < right),
+
+        private final BiFunction<Comparable, Comparable, Boolean> function
+        private final String literal
+
+        Operator(String literal, BiFunction<Comparable, Comparable, Boolean> function) {
+            this.literal = literal
+            this.function = function
+        }
+
+        boolean apply(Comparable left, Comparable right) { function.apply(left, right) }
+
+        String toString() { literal }
+
+        static Operator parse(String s) {
+            requireNonNull(
+                    values().find(it -> it.literal == s),
+                    /Syntax error: unrecognized operator: "$s" ; expected one of ${values()}/
+            )
+        }
+    }
+
+    @ImmutableOptions(knownImmutableClasses = ImplementationVersion.class)
+    static record Condition(Operator op, ImplementationVersion version) implements Predicate<ImplementationVersion> {
+        boolean test(ImplementationVersion actualVersion) { op.apply(actualVersion, version) }
+
+        String toString() { "$op$version" }
+    }
+
+    static Set<Condition> parseConditions(String conditions) {
+        if (conditions.count("&&") > 1) {
+            throw new IllegalArgumentException("Syntax error; can have at most 2 sub-conditions, but got: $conditions")
+        }
+
+        return conditions.split("&&").collect { condition ->
+            def matcher = condition =~ /(?<operator>[<=>]*)(?<version>\d\S*)/
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException(/Syntax error; invalid condition(s): "$conditions" ; expected something like: "1.2.0" or "<2.0.3" or "2.4.5&&<3.0.0"/)
+            }
+
+            def op = matcher.group("operator").with {
+                it == "" ? Operator.GTE : Operator.parse(it) // default to ">=" if absent
+            }
+            def version = ImplementationVersion.from(matcher.group("version"))
+            return new Condition(op, version)
+        }
+    }
+
+    @ImmutableOptions(knownImmutableClasses = Condition.class)
+    static record Tag(Type type, Set<Condition> conditions) implements Predicate<ImplementationVersion> {
+        enum Type {
+            IF, ELSE, END, SKIP
+        }
+
+        @Override
+        boolean test(ImplementationVersion version) {
+            return conditions().stream().allMatch(it -> it.test(version))
+        }
+
+        String toString() {
+            "[" + type.name().toLowerCase(Locale.ROOT) + (conditions().isEmpty() ? "" : (":" + conditions.join("&&"))) + "]"
+        }
+
+        static Tag parse(String line) {
+            def matcher = line =~ /\s*\[(?<tag>start|if|else|end|skip)(:(?<condition>\S*))?].*/
+            if (!matcher.matches()) return null
+
+            def tagName = matcher.group('tag').toUpperCase(Locale.ROOT)
+            if (tagName == "START") tagName = "IF"
+            def type = Type.valueOf(tagName)
+            def conditions = matcher.group('condition')
+            def tag = new Tag(type, conditions == null ? new LinkedHashSet<Condition>() : parseConditions(conditions))
+
+            if (tag.conditions.isEmpty() && !Set.of(Type.END, Type.ELSE).contains(type)) {
+                throw new IllegalArgumentException("Syntax error: missing condition for tag $tag")
+            }
+            if (!tag.conditions().isEmpty() && (type == Type.ELSE)) {
+                throw new IllegalArgumentException("Syntax error: $type tag must not have condition.")
+            }
+            return tag
+        }
+    }
+
+    enum Mode {
+        SKIPPING, INCLUDING
+    }
+
+    @ImmutableOptions(knownImmutableClasses = Tag.class)
+    static record TagStackFrame(Tag tag, Mode mode, String file, int lineNumber) {
+        String location() { file + ":" + lineNumber }
+    }
+
+    List<String> processTags(ImplementationVersion version) {
+        def warnings = new ArrayList()
+        var outputLines = new ArrayList<String>()
+
+        var stack = new ArrayDeque<TagStackFrame>()
+        stack.push(new TagStackFrame(new Tag(Tag.Type.IF, parseConditions("0.0.0")), Mode.INCLUDING, file.absolutePath, 0))
+
+        // First "un-skip" everything that might have been commented out by a previous run.
+        def restored = restore()
+
+        restored.eachLine { line, lineNumberZeroBased ->
+            def lineNumber = lineNumberZeroBased + 1
+            String location = "${file.absolutePath}:${lineNumber}"
+
+            try {
+                // Once we've seen a [skip] tag, never stop skipping!
+                if (stack.peek().tag().type() == Tag.Type.SKIP) {
+                    outputLines.add(addDeactivatedPrefix(line))
+                    return
+                }
+
+                def isConditionalComment = line =~ /\s*${Pattern.quote(conditionalCommentPrefix)}.*/
+                if (isConditionalComment) {
+                    if (stack.size() == 1) {
+                        throw new IllegalArgumentException("Encountered conditional comment outside of `if` or `else` block.")
+                    }
+                    if (stack.peek().mode() == Mode.INCLUDING) {
+                        line = activateCode(line)
+                    }
+                } else if (line =~ /\s*${Pattern.quote(commentPrefix)}\s*\[.+]/) { // looks like might be tag
+                    def tag = Tag.parse(line.substring(line.indexOf(commentPrefix) + commentPrefix.length()))
+                    if (tag != null) {
+                        if (tag.type() == Tag.Type.SKIP && tag.test(version)) {
+                            outputLines.add(addDeactivatedPrefix(line))
+                            stack.push(new TagStackFrame(tag, Mode.SKIPPING, file.absolutePath, lineNumber))
+                            return
+                        }
+
+                        if (tag.type() == Tag.Type.IF) {
+                            Mode newMode
+                            if (stack.peek().mode() == Mode.SKIPPING) {
+                                // can't un-skip -- the tag itself is being skipped too!
+                                newMode = Mode.SKIPPING
+                            } else {
+                                newMode = tag.test(version) ? Mode.INCLUDING : Mode.SKIPPING
+                            }
+                            stack.push(new TagStackFrame(tag, newMode, file.absolutePath, lineNumber))
+                        }
+
+                        if (tag.type() == Tag.Type.ELSE) {
+                            Mode newMode
+
+                            def startFrame = stack.pop()
+                            if (startFrame.tag().type() != Tag.Type.IF || stack.isEmpty()) {
+                                throw new IllegalArgumentException("Syntax error: encountered 'else' tag without 'if' tag.")
+                            }
+
+                            if (stack.peek().mode() == Mode.SKIPPING) {
+                                // we were skipping even before the "if" clause, so continue skipping
+                                newMode = Mode.SKIPPING
+                            } else {
+                                // "else" mode is the oppose of the "if" clause mode
+                                newMode = startFrame.mode() == Mode.SKIPPING ? Mode.INCLUDING : Mode.SKIPPING
+                            }
+                            stack.push(new TagStackFrame(tag, newMode, file.absolutePath, lineNumber))
+                        }
+
+                        if (tag.type() == Tag.Type.END) {
+                            Tag startTag = stack.peek().tag()
+                            if (startTag.type() != Tag.Type.IF && startTag.type() != Tag.Type.ELSE) {
+                                throw new IllegalArgumentException(
+                                        "Syntax error: Unbalanced tags." +
+                                                " Encountered end tag, but top of tag stack was not an start/if/else tag;" +
+                                                " instead was: $startTag from line ${stack.peek().lineNumber()}"
+                                )
+                            }
+                            if (!tag.conditions().isEmpty() && tag.conditions() != startTag.conditions()) {
+                                throw new IllegalArgumentException(
+                                        "Unbalanced tags." +
+                                                " End tag condition was specified (this is optional!), but does not match start tag condition." +
+                                                " Start tag from line ${stack.peek().lineNumber()}: ${startTag} End tag on line ${lineNumber}: ${tag}"
+                                )
+                            }
+                            // Emit it here, so it gets commented out even if it's ending a skipped section
+                            outputLines.add(stack.peek().mode() == Mode.SKIPPING ? addDeactivatedPrefix(line) : line)
+                            stack.pop()
+                            if (stack.isEmpty()) {
+                                throw new IllegalArgumentException("Unbalanced tags. End tag had no matching start tag.")
+                            }
+                            return
+                        }
+                    }
+                }
+
+                outputLines.add(stack.peek().mode() == Mode.SKIPPING ? addDeactivatedPrefix(line) : line)
+                return
+
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid tag at ${location} ; ${e} ; line was: \"${line}\"", e)
+            } catch (Exception e) {
+                throw new RuntimeException("Internal error in tag processor at ${location} ; ${e} ; line was: \"${line}\"", e)
+            }
+        }
+
+        if (stack.peek().tag().type() != Tag.Type.SKIP) {
+            while (stack.size() > 1) warnings.add("Unclosed tag at " + stack.pop().location())
+        }
+
+        def result = join(outputLines)
+
+        if (original != result) {
+            atomicWrite(file, result)
+        }
+
+        return warnings
+    }
+}

--- a/test/src/com/couchbase/tools/tags/TagProcessorV1Test.groovy
+++ b/test/src/com/couchbase/tools/tags/TagProcessorV1Test.groovy
@@ -1,0 +1,367 @@
+package com.couchbase.tools.tags
+
+import com.couchbase.versions.ImplementationVersion
+import org.junit.jupiter.api.Test
+
+import java.nio.file.Files
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+class TagProcessorV1Test {
+
+    @Test
+    void doesNotAddFinalNewlineIfNotPresentInOriginal() {
+        def input = new Input("""
+            #[if:2.0.0]
+            test
+            #[end]""")
+
+        input.check("1.0.0", """
+            # [DEACTIVATED]#[if:2.0.0]
+            # [DEACTIVATED]test
+            # [DEACTIVATED]#[end]""")
+    }
+
+    @Test
+    void simpleIfPreservesDescriptionAndWhitespace() {
+        // include some different leading whitespace to ensure it's preserved
+        def input = new Input("""
+            test
+              #[if:2.0.0]  description
+             test
+            #  [end]description
+            test
+            """)
+
+        input.check("2.0.0", """
+            test
+              #[if:2.0.0]  description
+             test
+            #  [end]description
+            test
+            """)
+
+        input.check("1.0.0", """
+            test
+            # [DEACTIVATED]  #[if:2.0.0]  description
+            # [DEACTIVATED] test
+            # [DEACTIVATED]#  [end]description
+            test
+            """)
+    }
+
+    @Test
+    void supportsLessThan() {
+        def input = new Input("""
+            # [if:<2.0.0]
+            test
+            # [end]
+            """)
+
+        input.check("1.0.0", """
+            # [if:<2.0.0]
+            test
+            # [end]
+            """)
+
+        input.check("2.0.0", """
+            # [DEACTIVATED]# [if:<2.0.0]
+            # [DEACTIVATED]test
+            # [DEACTIVATED]# [end]
+            """)
+    }
+
+    @Test
+    void recognizesStartAsAnAliasForIf() {
+        def input = new Input("""
+            # [start:2.0.0]
+            # [end:2.0.0]
+            """)
+
+        input.check("1.0.0", """
+            # [DEACTIVATED]# [start:2.0.0]
+            # [DEACTIVATED]# [end:2.0.0]
+            """)
+    }
+
+    @Test
+    void ignoresUnrecognizedTag() {
+        new Input("# [bogus]").check("1.0.0", "# [bogus]")
+        new Input("# [bogus:2.0.0]").check("1.0.0", "# [bogus:2.0.0]")
+    }
+
+    @Test
+    void notAConditionalCommentIfPrecededByWhitespace() {
+        new Input("# ?").check("1.0.0", "# ?")
+    }
+
+    @Test
+    void notATagIfPrecededByGarbage() {
+        new Input("# bogus [if:2.0.0]").check("1.0.0", "# bogus [if:2.0.0]")
+    }
+
+    @Test
+    void supportsNestedTags() {
+        def input = new Input("""
+            # [if:1.0.0]
+            test
+            # [if:2.0.0]
+            test
+            # [end]
+            test
+            # [end]
+            """)
+
+        input.check("1.0.0", """
+            # [if:1.0.0]
+            test
+            # [DEACTIVATED]# [if:2.0.0]
+            # [DEACTIVATED]test
+            # [DEACTIVATED]# [end]
+            test
+            # [end]
+            """)
+
+        input.check("2.0.0", """
+            # [if:1.0.0]
+            test
+            # [if:2.0.0]
+            test
+            # [end]
+            test
+            # [end]
+            """)
+    }
+
+    @Test
+    void innerIfIsAlwaysDeactivatedIfOuterIsDeactivated() {
+        def input = new Input("""
+            # [if:2.0.0]
+            test
+            # [if:1.0.0] should be deactivated because enclosing tag is deactivated
+            test
+            # [end]
+            test
+            # [end]
+            """)
+
+        input.check("1.0.0", """
+            # [DEACTIVATED]# [if:2.0.0]
+            # [DEACTIVATED]test
+            # [DEACTIVATED]# [if:1.0.0] should be deactivated because enclosing tag is deactivated
+            # [DEACTIVATED]test
+            # [DEACTIVATED]# [end]
+            # [DEACTIVATED]test
+            # [DEACTIVATED]# [end]
+            """)
+    }
+
+    @Test
+    void elseIsAlwaysDeactivatedIfOuterIsDeactivated() {
+        def input = new Input("""
+            # [if:2.0.0]
+            # [if:3.0.0]
+            # [else]
+            should be deactivated because outer "if:2.0.0" tag is deactivated
+            # [end]
+            # [end]
+            """)
+
+        input.check("1.0.0", """
+            # [DEACTIVATED]# [if:2.0.0]
+            # [DEACTIVATED]# [if:3.0.0]
+            # [DEACTIVATED]# [else]
+            # [DEACTIVATED]should be deactivated because outer "if:2.0.0" tag is deactivated
+            # [DEACTIVATED]# [end]
+            # [DEACTIVATED]# [end]
+            """)
+    }
+
+    @Test
+    void skipBypassesSubsequentTags() {
+        def input = new Input("""
+            test
+            # [skip:1.0.0]
+            # [if:invalidVersion] would be a syntax error if not skipped
+            test
+            """)
+
+        input.check("1.0.0", """
+            test
+            # [DEACTIVATED]# [skip:1.0.0]
+            # [DEACTIVATED]# [if:invalidVersion] would be a syntax error if not skipped
+            # [DEACTIVATED]test
+            """)
+    }
+
+    @Test
+    void unmatchedEndTagIsFatalError() {
+        new Input("# [end]").assertThrows("1.0.0", IllegalArgumentException.class)
+    }
+
+    @Test
+    void unmatchedElseTagIsFatalError() {
+        new Input("# [else]").assertThrows("1.0.0", IllegalArgumentException.class)
+        new Input("""
+            # [if:1.0.0]
+            # [else]
+            # [else]
+            # [end]
+            """).assertThrows("1.0.0", IllegalArgumentException.class)
+    }
+
+    @Test
+    void orphanConditionalCommentIsFatalError() {
+        new Input("#? foo").assertThrows("1.0.0", IllegalArgumentException.class)
+    }
+
+    @Test
+    void tooManyConditionsIsFatalError() {
+        new Input("# [if:1.0.0&&<2.0.0&&3.0.0]")
+                .assertThrows("1.0.0", IllegalArgumentException.class)
+    }
+
+    @Test
+    void malformedVersionIsFatalError() {
+        new Input("# [if:malformedVersion]")
+                .assertThrows("1.0.0", IllegalArgumentException.class)
+    }
+
+    @Test
+    void canOmitWhitespaceAfterConditionalCommentMarker() {
+        def input = new Input("""
+            # [if:1.0.0]
+                  #?foo
+            # [end]
+            """)
+
+        // Skip the restoration check, because the processor doesn't know
+        // how much whitespace was after #?
+        // TODO: encode the whitespace into the activation marker, like maybe
+        // between the comment prefix and the square bracket.
+        input.checkButSkipRestoration("1.0.0", """
+            # [if:1.0.0]
+                  foo # [ACTIVATED]
+            # [end]
+            """)
+    }
+
+    @Test
+    void activatesConditionalComments() {
+        def input = new Input("""
+            # [if:2.0.0]
+            #? foo
+            test
+            # [else]
+            #? bar
+            test
+            # [end]
+            """)
+
+        input.check("1.0.0", """
+            # [DEACTIVATED]# [if:2.0.0]
+            # [DEACTIVATED]#? foo
+            # [DEACTIVATED]test
+            # [else]
+            bar # [ACTIVATED]
+            test
+            # [end]
+            """)
+
+        input.check("2.0.0", """
+            # [if:2.0.0]
+            foo # [ACTIVATED]
+            test
+            # [DEACTIVATED]# [else]
+            # [DEACTIVATED]#? bar
+            # [DEACTIVATED]test
+            # [DEACTIVATED]# [end]
+            """)
+    }
+
+    @Test
+    void supportsSimpleCompoundConditions() {
+        def input = new Input("""
+            # [if:2.0.0&&<3.0.0]
+            foo
+            # [else]
+            bar
+            # [end]
+            """)
+
+        input.check("2.0.0", """
+            # [if:2.0.0&&<3.0.0]
+            foo
+            # [DEACTIVATED]# [else]
+            # [DEACTIVATED]bar
+            # [DEACTIVATED]# [end]
+            """)
+
+        input.check("3.0.0", """
+            # [DEACTIVATED]# [if:2.0.0&&<3.0.0]
+            # [DEACTIVATED]foo
+            # [else]
+            bar
+            # [end]
+            """)
+
+        input.check("1.0.0", """
+            # [DEACTIVATED]# [if:2.0.0&&<3.0.0]
+            # [DEACTIVATED]foo
+            # [else]
+            bar
+            # [end]
+            """)
+    }
+
+    static record Input(String original) {
+
+        <T extends Throwable> T assertThrows(String version, Class<T> exceptionClass) {
+            // Try with both kinds of tags, to make sure we didn't
+            // accidentally hard-code one type of tag in the processor.
+            assertThrows(exceptionClass, () -> doCheck(version, null, "//", true))
+            return assertThrows(exceptionClass, () -> doCheck(version, null, "#", true))
+        }
+
+        void checkButSkipRestoration(String version, String expected) {
+            doCheck(version, expected, "#", false)
+            doCheck(version, expected, "//", false)
+        }
+
+        void check(String version, String expected) {
+            // Try with both kinds of tags, to make sure we didn't
+            // accidentally hard-code one type of tag in the processor.
+            doCheck(version, expected, "#", true)
+            doCheck(version, expected, "//", true)
+        }
+
+        private void doCheck(String version, String expected, String commentMarker, boolean checkRestore) {
+            String extension = commentMarker == "#" ? ".rb" : ".java" // cheating for sure
+            String original = original.stripIndent().replace("#", commentMarker)
+            if (expected != null) {
+                expected = expected.replace("#", commentMarker)
+            }
+            File f = File.createTempFile("tag-processor-test-", extension);
+            try {
+                Files.writeString(f.toPath(), original);
+                TagProcessorV1.process(f, ImplementationVersion.from(version));
+
+                if (expected != null) {
+                    expected = expected.stripIndent()
+
+                    String processed = Files.readString(f.toPath());
+                    assertEquals(expected, processed, "tag processing");
+
+                    if (checkRestore) {
+                        TagProcessorV1.restoreFile(f);
+                        assertEquals(original, Files.readString(f.toPath()), "restoration");
+                    }
+                }
+
+            } finally {
+                f.delete();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ground-up rewrite of the tag processor to support nested conditions and if/else.

The processor now uses single-line comments to skip code. This is a potentially breaking change for performer code that relied on the previous behavior of using multi-line comments. To mitigate this, users must opt-in on a per-file basis by using at least one `if` tag.

Restoration is now a separate function. It's really simple: it just replaces all instances of "// [SKIPPED]" with an empty string, and puts "activated" code back the way it was before.

`processTags` no longer has an optional "restore" parameter. I didn't see it used anywhere; please confirm!