### PR TITLE
NCBC-3816: .NET Performer fails to build against certain versions

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
@@ -4,6 +4,7 @@ import com.couchbase.context.environments.Environment
 import com.couchbase.tools.tags.TagProcessor
 import com.couchbase.versions.ImplementationVersion
 import groovy.transform.CompileStatic
+import java.util.regex.Pattern
 
 @CompileStatic
 class BuildDockerDotNetPerformer {
@@ -18,14 +19,14 @@ class BuildDockerDotNetPerformer {
         imp.dirAbsolute(path) {
             imp.dir('transactions-fit-performer') {
                 //No need to use the submodule as the Dockerfile deletes it and runs a fresh clone
-                imp.dir('performers/dotnet') {
+                imp.dir('performers/dotnet/Couchbase.Transactions.FitPerformer') {
                     // couchbase-net-client is a git submodule
-                    TagProcessor.processTags(new File(imp.currentDir()), build)
+                    TagProcessor.processTags(new File(imp.currentDir()), build, Optional.of(Pattern.compile(".*\\.cs")))
                 }
             }
             if (!onlySource) {
                 var dockerfile = "Dockerfile_NET8"
-                if (build instanceof HasVersion && build.implementationVersion().isBelow(ImplementationVersion.from("3.4.10"))){
+                if (build instanceof HasVersion && build.implementationVersion().isBelow(ImplementationVersion.from("3.4.14"))){
                     dockerfile = "Dockerfile_NET6"
                 }
                 if (build instanceof BuildMain) {


### PR DESCRIPTION
Changes
-------
- Tag processor now only processes files inside the actual performer project
- Tag processor only processes ".cs" files
- Target framework is set to net8.0 only for SDK version >= to 3.4.14