### PR TITLE
Fix SHA parsing for Ruby/Python/C++ snapshot versions

### DIFF
--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -108,7 +108,7 @@ class Execute {
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for Python: ${sha}")
                     String version = PythonVersions.formatSnapshotVersion(highest, sha)
-                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("\\+").last(), true))
                 }
                 else if (implementation.language == "Node") {
                     def sha = NodeVersions.getLatestSha()
@@ -124,7 +124,7 @@ class Execute {
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for C++: ${sha}")
                     String version = CppVersions.formatSnapshotVersion(highest, sha)
-                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("\\+").last(), true))
                 }
                 else if (implementation.language == "Ruby") {
                     def sha = RubyVersions.getLatestSha()
@@ -132,7 +132,7 @@ class Execute {
                     def highest = ImplementationVersion.highest(allReleases)
                     ctx.env.log("Found latest sha for Ruby: ${sha}")
                     String version = RubyVersions.formatSnapshotVersion(highest, sha)
-                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("-").last(), true))
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("\\+").last(), true))
                 }
                 else {
                     throw new UnsupportedOperationException("Cannot support snapshot builds with language ${implementation.language} yet")


### PR DESCRIPTION
After a recent change, the SHA is now appended as build metadata with a `+` for Python, C++ and Ruby. Fix the code that extracts it when creating a `PerfConfig.Implementation`.