### PR TITLE
Don't run tag processor for C++

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerCppPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerCppPerformer.groovy
@@ -27,10 +27,6 @@ class BuildDockerCppPerformer {
 
         imp.dirAbsolute(path) {
             imp.dir('transactions-fit-performer') {
-                imp.dir('performers/cpp') {
-                    TagProcessor.processTags(new File(imp.currentDir()), build)
-                }
-
                 def serializedBuildArgs = dockerBuildArgs.collect((k, v) -> "--build-arg $k=$v").join(" ")
 
                 if (!onlySource) {


### PR DESCRIPTION
We don't need the tag processor to be called for C++, since we use C++'s own preprocessor directives