### PR TITLE
Update C++ snapshot version naming scheme

### DIFF
--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -119,12 +119,10 @@ class Execute {
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha, true))
                 }
                 else if (implementation.language == "C++") {
-                    def sha = CppVersions.getLatestSha()
-                    def allReleases = CppVersions.getAllReleases()
-                    def highest = ImplementationVersion.highest(allReleases)
-                    ctx.env.log("Found latest sha for C++: ${sha}")
-                    String version = CppVersions.formatSnapshotVersion(highest, sha)
-                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("\\+").last(), true))
+                    def version = CppVersions.getLatestSnapshot()
+                    ctx.env.log("Found latest snapshot for C++: ${version}")
+                    def sha = (version.snapshot != null && version.snapshot.contains('+')) ? version.snapshot.split("\\+").last() : null
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version.toString(), null, sha, true))
                 }
                 else if (implementation.language == "Ruby") {
                     def sha = RubyVersions.getLatestSha()

--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -1,17 +1,10 @@
 package com.couchbase.versions
 
-import com.couchbase.tools.network.NetworkUtil
 import groovy.transform.Memoized
-
 
 class CppVersions {
     private final static String REPO = "couchbase/couchbase-cxx-client"
     private final static String BRANCH = "main"
-
-    @Memoized
-    static String getLatestSha() {
-        return GithubVersions.getLatestShaWithDatetime(REPO, BRANCH)
-    }
 
     @Memoized
     static Set<ImplementationVersion> getAllReleases() {
@@ -19,8 +12,28 @@ class CppVersions {
         return withoutUnsupportedVersions(out)
     }
 
-    static String formatSnapshotVersion(ImplementationVersion version, String sha) {
-        return Versions.appendPreReleaseIdentifierToVersion(version.toString(), sha)
+    @Memoized
+    static ImplementationVersion getLatestSnapshot() {
+        return getSnapshot(ImplementationVersion.highest(getAllReleases()), GithubVersions.getLatestSha(REPO, BRANCH))
+    }
+
+    static ImplementationVersion getSnapshot(ImplementationVersion nearestRelease, String sha) {
+        def commitsSinceRelease = GithubVersions.commitsSinceTag(REPO, sha, nearestRelease.toString())
+        if (commitsSinceRelease == 0) {
+            return nearestRelease
+        }
+
+        String snapshot
+        int patch = nearestRelease.patch
+        if (nearestRelease.snapshot == null) {
+            // This commit is _after_ a non-RC release - increment the patch
+            patch += 1
+            snapshot = "-${commitsSinceRelease}+${sha.substring(0, 7)}"
+        } else {
+            snapshot = "${nearestRelease.snapshot}.${commitsSinceRelease}+${sha.substring(0, 7)}"
+        }
+
+        return new ImplementationVersion(nearestRelease.major, nearestRelease.minor, patch, snapshot)
     }
 
     /**

--- a/src/com/couchbase/versions/ImplementationVersion.groovy
+++ b/src/com/couchbase/versions/ImplementationVersion.groovy
@@ -79,8 +79,9 @@ class ImplementationVersion implements Comparable<ImplementationVersion> {
         if (patch > other.patch) return 1;
 
         if (snapshot && other.snapshot) {
-            var identifiers = snapshot.split('\\.')
-            var otherIdentifiers = other.snapshot.split('\\.')
+            // Anything after '+' is build metadata that doesn't affect ordering
+            var identifiers = snapshot.substring(1).split('\\+').first().split('\\.')
+            var otherIdentifiers = other.snapshot.substring(1).split('\\+').first().split('\\.')
             var shortestLength = Math.min(identifiers.length, otherIdentifiers.length)
 
             for (int i = 0; i < shortestLength; i++) {

--- a/test/src/com/couchbase/versions/CppVersionsTest.groovy
+++ b/test/src/com/couchbase/versions/CppVersionsTest.groovy
@@ -1,0 +1,72 @@
+package com.couchbase.versions
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
+
+class CppVersionsTest {
+    @Test
+    void latestSnapshotIsRelease() {
+        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3"), "b7086c059659d3f1e03a8d9bff266fad0c6c9b89")
+        assertEquals(1, snapshot.major)
+        assertEquals(0, snapshot.minor)
+        assertEquals(3, snapshot.patch)
+        assertNull(snapshot.snapshot)
+    }
+
+    @Test
+    void latestSnapshotIsReleaseCandidate() {
+        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3-rc.1"), "862fd4eb43327bc72ae494e49850bc04a39953e9")
+        assertEquals(1, snapshot.major)
+        assertEquals(0, snapshot.minor)
+        assertEquals(3, snapshot.patch)
+        assertEquals("-rc.1", snapshot.snapshot)
+    }
+
+    @Test
+    void latestSnapshotHasNumberOfCommitsSinceRelease() {
+        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3"), "aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880")
+        assertEquals(1, snapshot.major)
+        assertEquals(0, snapshot.minor)
+        assertEquals(4, snapshot.patch)
+        assertEquals("-3+aba976e", snapshot.snapshot)
+    }
+
+    @Test
+    void latestSnapshotHasNumberOfCommitsSinceReleaseCandidate() {
+        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3-rc.1"), "31fb90ead5d867b12a33154a1b3ff271d0c5ac79")
+        assertEquals(1, snapshot.major)
+        assertEquals(0, snapshot.minor)
+        assertEquals(3, snapshot.patch)
+        assertEquals("-rc.1.1+31fb90e", snapshot.snapshot)
+    }
+
+    @Test
+    void versionOrder() {
+        def versionList = Arrays.asList(
+                CppVersions.getSnapshot(ImplementationVersion.from("1.0.3-rc.1"), "31fb90ead5d867b12a33154a1b3ff271d0c5ac79"),
+                CppVersions.getSnapshot(ImplementationVersion.from("1.0.3"), "aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880"),
+                CppVersions.getSnapshot(ImplementationVersion.from("1.0.2"), "ae5370d8a1b4e0e047839f665ebbc0997629298b"),
+                ImplementationVersion.from("1.0.3-rc.2"),
+                ImplementationVersion.from("1.0.2"),
+                ImplementationVersion.from("1.0.3"),
+                ImplementationVersion.from("1.0.3-rc.1"),
+        )
+
+        versionList.sort(true)
+
+        assertEquals(
+                Arrays.asList(
+                        ImplementationVersion.from("1.0.2"),
+                        ImplementationVersion.from("1.0.3-4+ae5370d"),
+                        ImplementationVersion.from("1.0.3-rc.1"),
+                        ImplementationVersion.from("1.0.3-rc.1.1+31fb90e"),
+                        ImplementationVersion.from("1.0.3-rc.2"),
+                        ImplementationVersion.from("1.0.3"),
+                        ImplementationVersion.from("1.0.4-3+aba976e"),
+                ),
+                versionList
+        )
+    }
+}


### PR DESCRIPTION
## Changes

* In pre-release identifiers of snapshot versions, use the number of commits since the last tagged release, instead of date/time
* After a non-RC release (i.e. after a tag without pre-release identifiers), increment the patch. This ensures that these snapshot versions have higher precedence than the release, according to semver sorting rules.
* For snapshot builds where the commit is a tagged version, don't append the commit SHA or number of commits since tag (which would be 0) to the version
* Update `ImplementationVersion.compareTo()` to ignore the leading `-` and the build metadata (anything following a `+`)

For example:

```
1.0.2, 1.0.3-4+ae5370d, 1.0.3-rc.1, 1.0.3-rc.1.1+31fb90e, 1.0.3-rc.2, 1.0.3, 1.0.4-3+aba976e
```

Under the existing naming scheme, `1.0.4-3+aba976e` would be `1.0.3-20241028.183800+aba976e`