### PR TITLE
SDKQE-3477: Skip FIT-testing .NET SDK 3.4.5-rc2

### DIFF
--- a/src/com/couchbase/tools/performer/BuildPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildPerformer.groovy
@@ -143,9 +143,12 @@ class BuildPerformer {
                 case Sdk.DOTNET:
                     // 3.3.0 is earliest supported
                     def target = ImplementationVersion.from("3.3.0")
-                    def skipVersion = new ImplementationVersion(3, 4, 10, "rc1")
+                    def skipVersions = [
+                            new ImplementationVersion(3, 4, 10, "rc1"),
+                            new ImplementationVersion(3, 4, 5, "rc2")
+                    ]
                     def vers = DotNetVersions.allReleases
-                            .findAll { (it.isAbove(target) || it.equals(target)) && !it.equals(skipVersion)}
+                            .findAll { (it.isAbove(target) || it.equals(target)) && !skipVersions.contains(it)}
                     def implementation = new PerfConfig.Implementation(".NET", "3.X.0", null)
                     versions = Versions.versions(env, implementation, ".NET", vers)
                     break


### PR DESCRIPTION
## Motivation

SDK 3.4.5-rc2 mistakenly added .net8 to the target frameworks, which is removed in the release 3.4.5 until 3.4.14-rc4. jenkins-sdk is using the Dockerfile for .NET 6 only with 3.4.5-rc2(anything below 3.4.14).

This specific tag should be skipped for testing.