### PR TITLE
GOCBC-1682: Support BuildGerrit for Go performer

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerGoPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerGoPerformer.groovy
@@ -4,40 +4,47 @@ import com.couchbase.context.environments.Environment
 import com.couchbase.tools.tags.TagProcessor
 import groovy.transform.CompileStatic
 
+import java.util.regex.Pattern
+
 @CompileStatic
 class BuildDockerGoPerformer {
+    private static final String VERSION_ARG = "SDK_VERSION"
+    private static final String GERRIT_REF_ARG = "SDK_GERRIT_REF"
+
     /**
      * @param path absolute path to above 'transactions-fit-performer'
      * @param build what to build
      */
-    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false) {
+    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false, Map<String, String> dockerBuildArgs = [:]) {
         imp.log("Building Go ${build}")
-
-        if (build instanceof BuildSha || build instanceof BuildShaVersion) {
-            throw new RuntimeException("Building SHA not currently supported for Go")
-        }
-        if (build instanceof BuildGerrit) {
-            throw new RuntimeException("Building Gerrit not currently supported for Go")
-        }
 
         // Build context needs to be perf-sdk as we need the .proto files
         imp.dirAbsolute(path) {
             imp.dir('transactions-fit-performer') {
                 imp.dir('performers/go') {
-                    TagProcessor.processTags(new File(imp.currentDir()), build)
+                    TagProcessor.processTags(new File(imp.currentDir()), build, Optional.of(Pattern.compile(".*\\.go")))
                 }
-                var version = "master"
+
+                // We check HasSha and HasGerrit _before_ HasVersion, since BuildShaVersion & BuildGerritVersion
+                // implement HasVersion as well as HasSha/HasGerrit
                 if (build instanceof HasSha) {
-                    version = build.sha()
+                    dockerBuildArgs.put(VERSION_ARG, build.sha())
+                }
+                else if (build instanceof HasGerrit) {
+                    dockerBuildArgs.put(GERRIT_REF_ARG, build.gerrit())
                 }
                 else if (build instanceof HasVersion) {
-                    version = "v${build.version()}"
+                    dockerBuildArgs.put(VERSION_ARG, "v${build.version()}".toString())
                 }
                 else if (build instanceof BuildMain) {
-                    version = "master"
+                    dockerBuildArgs.put(VERSION_ARG, "master")
                 }
+
+
+                def serializedBuildArgs = dockerBuildArgs.collect((k, v) -> "--build-arg $k=$v").join(" ")
+
                 if (!onlySource) {
-                    imp.execute("docker build -f performers/go/Dockerfile --platform=linux/amd64 --build-arg SDK_VERSION=${version} -t $imageName .", false, true, true)
+                    imp.execute("docker build -f performers/go/Dockerfile --platform=linux/amd64 $serializedBuildArgs -t $imageName .", false, true, true)
                 }
             }
         }

--- a/src/com/couchbase/tools/performer/BuildPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildPerformer.groovy
@@ -83,6 +83,8 @@ class BuildPerformer {
         if (!validationMode) {
             if (version.isPresent() && sha.isPresent()) {
                 versionsToBuild.add(new BuildShaVersion(version.get(), sha.get()));
+            } else if (version.isPresent() && gerrit.isPresent()) {
+                versionsToBuild.add(new BuildGerritVersion(version.get(), gerrit.get()))
             } else if (sha.isPresent()) {
                 versionsToBuild.add(new BuildSha(sha.get()));
             } else if (version.isPresent()) {
@@ -189,7 +191,7 @@ class BuildPerformer {
                 if (sdk == Sdk.JAVA || sdk == Sdk.KOTLIN || sdk == Sdk.SCALA || sdk == Sdk.JAVA_COLUMNAR) {
                     BuildDockerJVMPerformer.build(env, dir, sdkRaw.replace("-sdk", ""), vers, imageName, onlySource)
                 } else if (sdk == Sdk.GO) {
-                    BuildDockerGoPerformer.build(env, dir, vers, imageName, onlySource)
+                    BuildDockerGoPerformer.build(env, dir, vers, imageName, onlySource, dockerBuildArgs)
                 } else if (sdk == Sdk.PYTHON) {
                     BuildDockerPythonPerformer.build(env, dir, vers, imageName, onlySource, dockerBuildArgs)
                 } else if (sdk == Sdk.CPP) {

--- a/src/com/couchbase/tools/performer/VersionToBuild.groovy
+++ b/src/com/couchbase/tools/performer/VersionToBuild.groovy
@@ -37,6 +37,10 @@ interface HasVersion {
     }
 }
 
+interface HasGerrit {
+    String gerrit()
+}
+
 /**
  * Build the current main branch.  Usually used when we don't care about specific versions - e.g. when doing functional
  * testing.
@@ -70,7 +74,7 @@ record BuildSha(String sha) implements VersionToBuild, HasSha {
 /**
  * Build a specific SHA, e.g. "20e862d".  Usually used for a snapshot build.
  *
- * Unlike BuildSha, Here we do know the version this sha corresponds to, so the tag processor will be run.
+ * Unlike BuildSha, here we do know the version this sha corresponds to, so the tag processor will be run.
  */
 record BuildShaVersion(String version, String sha) implements VersionToBuild, HasSha, HasVersion {
     @Override
@@ -100,11 +104,26 @@ record BuildVersion(String version) implements VersionToBuild, HasVersion {
  *
  * For the same reasons as `BuildSha`, the tags processor is not run in this mode.
  */
-record BuildGerrit(String gerrit) implements VersionToBuild {
+record BuildGerrit(String gerrit) implements VersionToBuild, HasGerrit {
     @Override
     public String toString() {
         return "BuildGerrit{" +
                 "gerrit='" + gerrit + '\'' +
+                '}';
+    }
+}
+
+/**
+ * Build from a specific Gerrit changeset, e.g. "refs/changes/94/184294/1".
+ *
+ * Unlike `BuildGerrit`, here we do know the version this changeset corresponds to, so the tag processor will be run.
+ */
+record BuildGerritVersion(String version, String gerrit) implements VersionToBuild, HasVersion, HasGerrit {
+    @Override
+    public String toString() {
+        return "BuildGerritVersion{" +
+                "version='" + version + '\'' +
+                ", gerrit='" + gerrit + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
## Changes

### Go-specific

* Add support for `BuildGerrit` in `BuildDockerGoPerformer` that uses the `SDK_GERRIT_REF` docker build argument (needs the relevant [performer change](https://review.couchbase.org/c/transactions-fit-performer/+/219970))
* The tag processor now only processes files with the `.go` file extension
* We now longer throw an exception if `BuildSha` or `BuildShaVersion` is provided – they are already supported
* Allow passing free-form docker build arguments

### General

* Add `BuildGerritVersion`, which allows both specifying a gerrit patch and running the tag processor – similar to `BuildShaVersion`
* Add `HasGerrit` to allow grouping `BuildGerrit` & `BuildGerritVersion` together
