### PR TITLE
SDKQE-3529: Update C++ snapshot label logic to take into account new branching approach

### DIFF
--- a/src/com/couchbase/versions/CppVersions.groovy
+++ b/src/com/couchbase/versions/CppVersions.groovy
@@ -14,26 +14,12 @@ class CppVersions {
 
     @Memoized
     static ImplementationVersion getLatestSnapshot() {
-        return getSnapshot(ImplementationVersion.highest(getAllReleases()), GithubVersions.getLatestSha(REPO, BRANCH))
+        return getSnapshot(BRANCH, true) // The next release on main is now always a dot-minor.
     }
 
-    static ImplementationVersion getSnapshot(ImplementationVersion nearestRelease, String sha) {
-        def commitsSinceRelease = GithubVersions.commitsSinceTag(REPO, sha, nearestRelease.toString())
-        if (commitsSinceRelease == 0) {
-            return nearestRelease
-        }
-
-        String snapshot
-        int patch = nearestRelease.patch
-        if (nearestRelease.snapshot == null) {
-            // This commit is _after_ a non-RC release - increment the patch
-            patch += 1
-            snapshot = "-${commitsSinceRelease}+${sha.substring(0, 7)}"
-        } else {
-            snapshot = "${nearestRelease.snapshot}.${commitsSinceRelease}+${sha.substring(0, 7)}"
-        }
-
-        return new ImplementationVersion(nearestRelease.major, nearestRelease.minor, patch, snapshot)
+    static ImplementationVersion getSnapshot(String shaOrBranch, boolean nextReleaseIsDotMinor) {
+        def attrs = GithubVersions.getSnapshotAttributes(REPO, shaOrBranch)
+        return attrs.toImplementationVersion(nextReleaseIsDotMinor)
     }
 
     /**

--- a/test/src/com/couchbase/versions/CppVersionsTest.groovy
+++ b/test/src/com/couchbase/versions/CppVersionsTest.groovy
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull
 class CppVersionsTest {
     @Test
     void latestSnapshotIsRelease() {
-        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3"), "b7086c059659d3f1e03a8d9bff266fad0c6c9b89")
+        def snapshot = CppVersions.getSnapshot("b7086c059659d3f1e03a8d9bff266fad0c6c9b89", false)
         assertEquals(1, snapshot.major)
         assertEquals(0, snapshot.minor)
         assertEquals(3, snapshot.patch)
@@ -17,7 +17,7 @@ class CppVersionsTest {
 
     @Test
     void latestSnapshotIsReleaseCandidate() {
-        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3-rc.1"), "862fd4eb43327bc72ae494e49850bc04a39953e9")
+        def snapshot = CppVersions.getSnapshot("862fd4eb43327bc72ae494e49850bc04a39953e9", false)
         assertEquals(1, snapshot.major)
         assertEquals(0, snapshot.minor)
         assertEquals(3, snapshot.patch)
@@ -26,7 +26,7 @@ class CppVersionsTest {
 
     @Test
     void latestSnapshotHasNumberOfCommitsSinceRelease() {
-        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3"), "aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880")
+        def snapshot = CppVersions.getSnapshot("aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880", false)
         assertEquals(1, snapshot.major)
         assertEquals(0, snapshot.minor)
         assertEquals(4, snapshot.patch)
@@ -34,8 +34,17 @@ class CppVersionsTest {
     }
 
     @Test
+    void latestSnapshotHasNumberOfCommitsSinceReleaseDotMinorBump() {
+        def snapshot = CppVersions.getSnapshot("aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880", true)
+        assertEquals(1, snapshot.major)
+        assertEquals(1, snapshot.minor)
+        assertEquals(0, snapshot.patch)
+        assertEquals("-3+aba976e", snapshot.snapshot)
+    }
+
+    @Test
     void latestSnapshotHasNumberOfCommitsSinceReleaseCandidate() {
-        def snapshot = CppVersions.getSnapshot(ImplementationVersion.from("1.0.3-rc.1"), "31fb90ead5d867b12a33154a1b3ff271d0c5ac79")
+        def snapshot = CppVersions.getSnapshot("31fb90ead5d867b12a33154a1b3ff271d0c5ac79", false)
         assertEquals(1, snapshot.major)
         assertEquals(0, snapshot.minor)
         assertEquals(3, snapshot.patch)
@@ -45,9 +54,9 @@ class CppVersionsTest {
     @Test
     void versionOrder() {
         def versionList = Arrays.asList(
-                CppVersions.getSnapshot(ImplementationVersion.from("1.0.3-rc.1"), "31fb90ead5d867b12a33154a1b3ff271d0c5ac79"),
-                CppVersions.getSnapshot(ImplementationVersion.from("1.0.3"), "aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880"),
-                CppVersions.getSnapshot(ImplementationVersion.from("1.0.2"), "ae5370d8a1b4e0e047839f665ebbc0997629298b"),
+                CppVersions.getSnapshot("31fb90ead5d867b12a33154a1b3ff271d0c5ac79", false),
+                CppVersions.getSnapshot("aba976e4756cd5b9f4ba4c8ad9f99b215d1f2880", false),
+                CppVersions.getSnapshot("ae5370d8a1b4e0e047839f665ebbc0997629298b", false),
                 ImplementationVersion.from("1.0.3-rc.2"),
                 ImplementationVersion.from("1.0.2"),
                 ImplementationVersion.from("1.0.3"),


### PR DESCRIPTION
This changes how we find the "nearest release". Instead of getting the tag with the highest value according to semver sorting rules, we find the tag that is the least amount of commits away from the specified commit, on the specified branch.

Another change is that we now increment the dot-minor for snapshots on `main` that are not after a pre-release tag.