### PR TITLE
NCBC-3966: Update FIT-PERF job-config.yaml to add newer versions the SDK

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -131,6 +131,12 @@ matrix:
       version: 3.4.X
 
     - language: .NET
+      version: 3.5.X
+
+    - language: .NET
+      version: 3.6.X
+
+    - language: .NET
       version: snapshot
 
     # Earliest version the Go performer can compile is 2.3.0 (possibly earlier)


### PR DESCRIPTION
## Motivation
The latest .NET minor specified in the FIT-perf job config is 3.4.X, meaning the latest version displayed as non-snapshot on the performance dashboard is 3.4.14.

## Changes
- Added minor 3.5.X and 3.6.X