### PR TITLE
database changes to include jobs

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -2,7 +2,7 @@
 # The tools will work out all permutations of runs from this.
 # They will interrogate the database and see what runs already exist.
 # Any runs that need running, will be.
-
+jobId: Random_Job_ID
 servers:
   # This is where the performers should run.  Currently only "localhost" is supported.
   # In future we want to supported scp-ing the performers to a remote host.

--- a/src/com/couchbase/perf/sdk/stages/OutputPerformerConfig.groovy
+++ b/src/com/couchbase/perf/sdk/stages/OutputPerformerConfig.groovy
@@ -98,6 +98,7 @@ class OutputPerformerConfig extends Stage {
             }
             runs runsAsYaml
             settings topLevelSettings
+            jobId ctx.jc.jobId
         }
 
         def converted = YamlConverter.convertJsonToYaml(new StringReader(json.toString()))

--- a/src/com/couchbase/perf/shared/database/PerfDatabase.groovy
+++ b/src/com/couchbase/perf/shared/database/PerfDatabase.groovy
@@ -68,6 +68,24 @@ class PerfDatabase {
         // JSONB indexes
         execute(sql, env, "CREATE INDEX IF NOT EXISTS idx_runs_params ON runs USING gin (params)")
         execute(sql, env, "CREATE INDEX IF NOT EXISTS idx_runs_events_params ON run_events USING gin (params)")
+        // New Jobs table to hold an overlying job for grouping runs
+        execute(sql, env, "CREATE TABLE IF NOT EXISTS jobs ("
+                + "id uuid PRIMARY KEY, "
+                + "datetime timestamp NOT NULL DEFAULT now(), "
+                + "config jsonb, "
+                + "tags TEXT[] DEFAULT NULL"
+                + ")");
+        // Join table to link jobs with runs
+        execute(sql, env, "CREATE TABLE IF NOT EXISTS job_runs ("
+                + "job_id UUID REFERENCES jobs(id) ON DELETE CASCADE, "
+                + "run_id UUID REFERENCES runs(id) ON DELETE CASCADE, "
+                + "PRIMARY KEY (job_id, run_id)"
+                + ")");
+        // Indexes for the new tables
+        execute(sql, env, "CREATE INDEX IF NOT EXISTS idx_jobs_datetime ON jobs (datetime)");
+        execute(sql, env, "CREATE INDEX IF NOT EXISTS idx_jobs_tags ON jobs USING gin (tags)");  
+        execute(sql, env, "CREATE INDEX IF NOT EXISTS idx_job_runs_job_id ON job_runs (job_id)");
+        execute(sql, env, "CREATE INDEX IF NOT EXISTS idx_job_runs_run_id ON job_runs (run_id)"); 
     }
 
     /**


### PR DESCRIPTION
- Added new table setup to hold jobs,
      -  Job is a wrapper around all tasks under 1 job-config file
- Another table to hold related job, run ids
- Made a few indexes to help with fetches
- Updated the job-config to hold jobId to be passed to transaction-fit-performer