### PR TITLE
Allow docker-build-args buildPerformer param for Go

### DIFF
--- a/src/com/couchbase/tools/performer/BuildPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildPerformer.groovy
@@ -68,7 +68,7 @@ class BuildPerformer {
 
         Map<String, String> dockerBuildArgs = new HashMap<>()
         if (options.a) {
-            if (!(sdk in [Sdk.CPP, Sdk.PYTHON, Sdk.RUBY])) {
+            if (!(sdk in [Sdk.CPP, Sdk.PYTHON, Sdk.RUBY, Sdk.GO, Sdk.GO_COLUMNAR])) {
                 logger.severe("The docker-build-args parameter cannot be set for the ${sdk.name()} SDK.")
                 System.exit(-1)
             }


### PR DESCRIPTION
We already have the requirements in place to specify free-form docker build params for Go and Go columnar. We need update the parameter validation to allow that.