### PR TITLE
[Go] Provide commit SHA to docker build for BuildMain to prevent use of cached main

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerGoPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerGoPerformer.groovy
@@ -1,6 +1,7 @@
 package com.couchbase.tools.performer
 
 import com.couchbase.context.environments.Environment
+import com.couchbase.tools.network.NetworkUtil
 import com.couchbase.tools.tags.TagProcessor
 import groovy.transform.CompileStatic
 
@@ -37,7 +38,10 @@ class BuildDockerGoPerformer {
                     dockerBuildArgs.put(VERSION_ARG, "v${build.version()}".toString())
                 }
                 else if (build instanceof BuildMain) {
-                    dockerBuildArgs.put(VERSION_ARG, "master")
+                    // If we set SDK_VERSION to "master", docker might cache the result of an earlier go get command result.
+                    // This means we could end up using an outdated version of master. We should fetch the latest commit SHA here and provide that to prevent this.
+                    def json = NetworkUtil.readJson("https://proxy.golang.org/github.com/couchbase/gocb/v2/@v/master.info")
+                    dockerBuildArgs.put(VERSION_ARG, json["Origin"]["Hash"] as String)
                 }
 
 


### PR DESCRIPTION
Docker caches the build steps, including the `go get github.com/couchbase/gocb/v2@master` step, which builds that the performer build will not necessarily use the latest version of master. We should provide the SHA of the latest commit to the docker build to prevent this.