### PR TITLE
Add dotnet 3.8.X to peformance website

### DIFF
--- a/config/job-config.yaml
+++ b/config/job-config.yaml
@@ -143,7 +143,7 @@ matrix:
       version: 3.7.X
 
     - language: .NET
-      version: 3.7.X
+      version: 3.8.X
 
     - language: .NET
       version: snapshot


### PR DESCRIPTION
version 3.7.x was added twice, so made one 3.8.x.