### PR TITLE
RSCBC-137: Add Rust to Perf dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build
 
+workspace
+
 .idea
 
 .vscode

--- a/src/com/couchbase/perf/sdk/stages/BuildDockerRustSDKPerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/BuildDockerRustSDKPerformer.groovy
@@ -10,19 +10,21 @@ import groovy.transform.CompileStatic
 class BuildDockerRustSDKPerformer extends Stage{
 
     private final String sdkVersion
+    private final String sha
     final String imageName
 
     static String genImageName(String sdkVersion) {
-        return "performer-rust" + sdkVersion
+        return "performer-rust" + sdkVersion.replace('+', '-')
     }
 
-    BuildDockerRustSDKPerformer(String sdkVersion) {
-        this(BuildDockerRustSDKPerformer.genImageName(sdkVersion), sdkVersion)
+    BuildDockerRustSDKPerformer(String sdkVersion, String sha) {
+        this(genImageName(sdkVersion), sdkVersion, sha)
     }
 
-    BuildDockerRustSDKPerformer(String imageName, String sdkVersion) {
+    BuildDockerRustSDKPerformer(String imageName, String sdkVersion, String sha) {
         this.sdkVersion = sdkVersion
         this.imageName = imageName
+        this.sha = sha
     }
 
     @Override
@@ -32,7 +34,7 @@ class BuildDockerRustSDKPerformer extends Stage{
 
     @Override
     void executeImpl(StageContext ctx) {
-        BuildDockerRustPerformer.build(ctx.env, ctx.sourceDir(), VersionToBuildUtil.from(sdkVersion, null), imageName)
+        BuildDockerRustPerformer.build(ctx.env, ctx.sourceDir(), VersionToBuildUtil.from(sdkVersion, sha), imageName)
     }
 
     String getImageName(){

--- a/src/com/couchbase/perf/sdk/stages/InitialiseSDKPerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/InitialiseSDKPerformer.groovy
@@ -65,6 +65,10 @@ class InitialiseSDKPerformer extends Stage {
                 def stage1 = new BuildDockerRubySDKPerformer(impl.version(), impl.sha)
                 imageName = stage1.imageName
                 return produceStages(ctx, stage1, stage1.getImageName())
+            } else if (impl.language == "Rust") {
+                def stage1 = new BuildDockerRustSDKPerformer(impl.version(), impl.sha)
+                imageName = stage1.imageName
+                return produceStages(ctx, stage1, stage1.getImageName())
             } else {
                 throw new IllegalArgumentException("Unknown performer ${impl.language}")
             }

--- a/src/com/couchbase/perf/shared/main/main.groovy
+++ b/src/com/couchbase/perf/shared/main/main.groovy
@@ -134,13 +134,10 @@ class Execute {
                     implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version, null, sha.split("\\+").last(), true))
                 }
                 else if (implementation.language == "Rust") {
-                    def snapshot = RustVersions.getLatestCargoEntry()
-                    if (snapshot == null) {
-                        ctx.env.log("Skipping rust snapshot")
-                    } else {
-                        ctx.env.log("Found cargo entry for Rust: ${snapshot}")
-                        implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, snapshot, null, null, true))
-                    }
+                    def version = RustVersions.getLatestSnapshotPrerelease()
+                    def sha = (version.snapshot != null && version.snapshot.contains('+')) ? version.snapshot.split("\\+").last() : null
+                    ctx.env.log("Found latest snapshot for Rust: ${version}")
+                    implementationsToAdd.add(new PerfConfig.Implementation(implementation.language, version.toString(), null, sha, true))
                 }
                 else {
                     throw new UnsupportedOperationException("Cannot support snapshot builds with language ${implementation.language} yet")

--- a/src/com/couchbase/tools/performer/BuildDockerRustPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerRustPerformer.groovy
@@ -4,6 +4,8 @@ import com.couchbase.context.environments.Environment
 import com.couchbase.tools.tags.TagProcessor
 import groovy.transform.CompileStatic
 
+import java.util.regex.Pattern
+
 class BuildDockerRustPerformer {
     private static String master = "main"
 
@@ -18,14 +20,14 @@ class BuildDockerRustPerformer {
         imp.dirAbsolute(path) {
             imp.dir('transactions-fit-performer') {
                 imp.dir("performers/rust") {
-                    TagProcessor.processTags(new File(imp.currentDir()), build)
+                    TagProcessor.processTags(new File(imp.currentDir()), build, Optional.of(Pattern.compile(".*\\.rs")))
                 }
                 if (!onlySource) {
                     if (build instanceof BuildMain) {
                         imp.execute("docker build -f performers/rust/Dockerfile -t $imageName .", false, true, true)
                     }
                     else if (build instanceof HasSha) {
-                        imp.execute("docker build -f performers/rust/Dockerfile -t $imageName --build-arg SDK_BRANCH=${build.sha()} .", false, true, true)
+                        imp.execute("docker build -f performers/rust/Dockerfile -t $imageName --build-arg SDK_SHA=${build.sha()} .", false, true, true)
                     }
                     else if (build instanceof HasVersion) {
                         imp.execute("docker build -f performers/rust/Dockerfile -t $imageName --build-arg SDK_TAG=${build.version()} .", false, true, true)

--- a/src/com/couchbase/versions/RustVersions.groovy
+++ b/src/com/couchbase/versions/RustVersions.groovy
@@ -3,9 +3,21 @@ package com.couchbase.versions
 import com.couchbase.tools.network.NetworkUtil
 import groovy.transform.Memoized
 
-
 class RustVersions {
-    private final static String REPO = "couchbase/couchbase-rs"
+    private final static String REPO = "couchbaselabs/couchbase-rs"
+    private final static String BRANCH = "main"
+
+    // The Rust SDK hasn’t had an official release yet. Since it was merged into the
+    // same repo/branch as the old deprecated SDK, the most recent Git tag belongs
+    // to that code. To avoid counting commits from the wrong history,
+    // we pin a reference commit (the first commit of the native SDK) and arbitrarily call
+    // it version 0.1.0 to keep it easily sortable against future releases.
+    //
+    // Pre-release versions are in the form:
+    //   0.1.0-<commit count since reference commit>+<SHA>
+    private final static String referenceSha = "0d1a6fdfa39adff00d5960a5d907efd1f49ee1a2"
+    private final static ImplementationVersion referenceVersion = ImplementationVersion.from("0.0.0")
+
 
     @Memoized
     static String getLatestCargoEntry() {
@@ -16,6 +28,17 @@ class RustVersions {
 
     @Memoized
     static Set<ImplementationVersion> getAllReleases() {
-        return GithubVersions.getAllReleases(REPO)
+        var allReleases = GithubVersions.getAllReleases(REPO).findAll()
+        // We want to exclude non-native Rust SDK releases, which are all pre-1.0.0
+        return allReleases.findAll { version -> version.major != 0 }
+    }
+
+    static ImplementationVersion getLatestSnapshotPrerelease() {
+        return getSnapshotPrerelease(BRANCH)
+    }
+
+    static ImplementationVersion getSnapshotPrerelease(String sha) {
+        def attrs = GithubVersions.getSnapshotAttributesUsingReferenceCommit(REPO, sha, referenceSha, referenceVersion)
+        return attrs.toImplementationVersion(true)
     }
 }


### PR DESCRIPTION
Changes:
- Added `getSnapshotAttributesFromCommit` function, to more accurately describe when native Rust SDK development started, as the repo is shared/merged with the deprecated non-native Rust SDK
- Change snapshot builds to pull from Github instead of Cargo
- Small misc fixes

Note: Pre developer preview versions will be labelled `0.1.0-<Commits From Initial>+<SHA>`