### PR TITLE
Simplify conditional external transactions handling for .NET

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
@@ -37,11 +37,10 @@ class BuildDockerDotNetPerformer {
                 dockerBuildArgs.put('FIT_DOTNET_VERSION', dotnetVersion)
 
                 // The external Transactions project was removed between SDK 3.9.0 and 3.9.1, but was deprecated since 3.6.6.
-                // If we're building for a version below 3.6.6, we need to use the backup .sln which includes the external
-                // project and references.  
-                // For versions above 3.6.6, we can just use the normal .sln which doesn't include the external project.
+                // For versions below 3.6.6, the Dockerfile will copy ExternalCouchbaseTransactions.sln.bak over the
+                // solution file and add a ProjectReference to the external Couchbase.Transactions project.
                 if (build instanceof HasVersion && build.implementationVersion().isBelow(ImplementationVersion.from("3.6.6"))){
-                    imp.copyFile('transactions-fit-performer/performers/dotnet/Couchbase.Transactions.FitPerformer/ExternalCouchbaseTransactions.sln.bak', 'transactions-fit-performer/performers/dotnet/Couchbase.Transactions.FitPerformer/Couchbase.Transactions.FitPerformer.sln')
+                    dockerBuildArgs.put('EXTERNAL_TRANSACTIONS', 'yes')
                 }
 
                 if (build instanceof BuildMain) {


### PR DESCRIPTION
It's easier for iterations to have jenkins-sdk set a flag in the performer's Dockerfile to use external transactions, then the Dockerfile can decide what processing to do to make that possible.