### PR TITLE
Add foojay-resolver-convention plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
-rootProject.name = 'jenkins2'
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
 
+rootProject.name = 'jenkins2'


### PR DESCRIPTION
`build.gradle` requests a Java 11 toolchain `(languageVersion.set(JavaLanguageVersion.of(11)))`, but the CI Linux x86_64 agent doesn't have JDK 11 installed.  

We can add the `foojay-resolver-convention` plugin so Gradle can auto-download a matching JDK.