### PR TITLE
Upgrade to using Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 


### PR DESCRIPTION
Gradle 8.3 requires Java 17 or later: https://docs.gradle.org/current/userguide/compatibility.html