### PR TITLE
Support PERFORMER_BUILD_ARGS injection for .NET Performers

### DIFF
--- a/src/com/couchbase/tools/performer/BuildDockerAnalyticsDotNetPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerAnalyticsDotNetPerformer.groovy
@@ -20,7 +20,8 @@ class BuildDockerAnalyticsDotNetPerformer {
             String path,
             VersionToBuild build,
             String imageName,
-            boolean onlySource = false
+            boolean onlySource = false,
+            Map<String, String> extraDockerBuildArgs = [:]
     ) {
         env.log("Building analytics-dotnet ${build}")
 
@@ -37,6 +38,10 @@ class BuildDockerAnalyticsDotNetPerformer {
                 "FIT_DOTNET_VERSION": dotnetVersion,
                 "SDK_GIT_REV"       : gitRev(build),
         ]
+        if (extraDockerBuildArgs) {
+            dockerBuildArgs.putAll(extraDockerBuildArgs)
+        }
+        
         def serializedBuildArgs = dockerBuildArgs.collect((k, v) -> "--build-arg $k=$v").join(" ")
 
         env.dirAbsolute(path) {

--- a/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildDockerDotNetPerformer.groovy
@@ -12,7 +12,7 @@ class BuildDockerDotNetPerformer {
      * @param path absolute path to above 'transactions-fit-performer'
      * @param build what to build
      */
-    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false) {
+    static void build(Environment imp, String path, VersionToBuild build, String imageName, boolean onlySource = false, Map<String, String> extraDockerBuildArgs = [:]) {
         imp.log("Building .NET ${build}")
 
         // Build context needs to be perf-sdk as we need the .proto files
@@ -26,6 +26,9 @@ class BuildDockerDotNetPerformer {
             }
             if (!onlySource) {
                 Map<String, String> dockerBuildArgs = [:]
+                if (extraDockerBuildArgs) {
+                    dockerBuildArgs.putAll(extraDockerBuildArgs)
+                }
 
                 var dotnetVersion = '10.0'
                 if (build instanceof HasVersion && build.implementationVersion().isBelow(ImplementationVersion.from("3.8.2"))){
@@ -46,7 +49,7 @@ class BuildDockerDotNetPerformer {
                 if (build instanceof BuildMain) {
                     // no extra build args
                 }
-                else if (build instanceof BuildGerrit) {
+                else if (build instanceof HasGerrit) {
                     dockerBuildArgs.put('BUILD_GERRIT', build.gerrit())
                 }
                 else if (build instanceof HasSha) {

--- a/src/com/couchbase/tools/performer/BuildPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildPerformer.groovy
@@ -78,8 +78,9 @@ class BuildPerformer {
                                                 Sdk.GO_COLUMNAR,
                                                 Sdk.PYTHON_ANALYTICS,
                                                 Sdk.RUST,
-                                                Sdk.PYTHON_COLUMNAR,
-                                                Sdk.NODE_COLUMNAR]
+                                                Sdk.NODE_COLUMNAR,
+                                                Sdk.DOTNET,
+                                                Sdk.DOTNET_ANALYTICS]
             if (!(sdk in sdksWithBuildArgs)) {
                 logger.severe("The docker-build-args parameter cannot be set for the ${sdk.name()} SDK.")
                 System.exit(-1)
@@ -217,7 +218,7 @@ class BuildPerformer {
                 } else if (sdk == Sdk.RUBY) {
                     BuildDockerRubyPerformer.build(env, dir, vers, imageName, onlySource, dockerBuildArgs)
                 } else if (sdk == Sdk.DOTNET) { // "dotnet" alias to support test-driver CI job
-                    BuildDockerDotNetPerformer.build(env, dir, vers, imageName, onlySource)
+                    BuildDockerDotNetPerformer.build(env, dir, vers, imageName, onlySource, dockerBuildArgs)
                 } else if (sdk == Sdk.NODE) {
                     BuildDockerNodePerformer.build(env, dir, vers, imageName, onlySource)
                 } else if (sdk == Sdk.RUST) {
@@ -235,7 +236,7 @@ class BuildPerformer {
                 } else if (sdk == Sdk.NODE_ANALYTICS) {
                     BuildDockerAnalyticsNodePerformer.build(env, dir, vers, imageName, onlySource, dockerBuildArgs)
                 } else if (sdk == Sdk.DOTNET_ANALYTICS) {
-                    BuildDockerAnalyticsDotNetPerformer.build(env, dir, vers, imageName, onlySource)
+                    BuildDockerAnalyticsDotNetPerformer.build(env, dir, vers, imageName, onlySource, dockerBuildArgs)
                 } else {
                     logger.severe("Do not yet know how to build " + sdkRaw)
                 }

--- a/src/com/couchbase/tools/performer/BuildPerformer.groovy
+++ b/src/com/couchbase/tools/performer/BuildPerformer.groovy
@@ -78,6 +78,7 @@ class BuildPerformer {
                                                 Sdk.GO_COLUMNAR,
                                                 Sdk.PYTHON_ANALYTICS,
                                                 Sdk.RUST,
+                                                Sdk.PYTHON_COLUMNAR,
                                                 Sdk.NODE_COLUMNAR,
                                                 Sdk.DOTNET,
                                                 Sdk.DOTNET_ANALYTICS]


### PR DESCRIPTION
Allows passing Gerrit patchsets to .NET builders via Jenkins PERFORMER_BUILD_ARGS parameter without upstream Jenkinsfile modification.