### PR TITLE
Support pulling pre-built performer images from ghcr.io

### DIFF
--- a/src/com/couchbase/context/StageContext.groovy
+++ b/src/com/couchbase/context/StageContext.groovy
@@ -49,6 +49,11 @@ class StageContext {
     }
 
     @CompileDynamic
+    boolean usePrebuiltImages() {
+        return jc.variables.usePrebuiltImages
+    }
+
+    @CompileDynamic
     boolean stopOnFailure() {
         return jc.variables.stopOnFailure
     }

--- a/src/com/couchbase/perf/sdk/stages/InitialiseSDKPerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/InitialiseSDKPerformer.groovy
@@ -1,6 +1,5 @@
 package com.couchbase.perf.sdk.stages
 
-import com.couchbase.perf.shared.config.PerfConfig.Implementation
 import com.couchbase.stages.Stage
 import groovy.transform.CompileStatic
 import com.couchbase.context.StageContext
@@ -29,25 +28,19 @@ class InitialiseSDKPerformer extends Stage {
         return "Init performer $impl"
     }
 
-    private String prebuiltImageName(Implementation sdk) {
-        // This will be available soon, but currently requires login
-//        if (!sdk.isSnapshot) {
-//            return "ghcr.io/couchbaselabs/${sdk.language.toLowerCase()}-fit-performer:${sdk.version}"
-//        }
-        return null
-    }
-
     @Override
     List<Stage> stagesPre(StageContext ctx) {
         if (impl.port != null) {
             // Nothing to do
             return []
         }
+        else if (ctx.usePrebuiltImages()) {
+            String prebuiltImage = PrebuiltPerformerImage.imageName(impl)
+            imageName = prebuiltImage
+            return produceStages(ctx, null, prebuiltImage)
+        }
         else {
-            String prebuiltImage = prebuiltImageName(impl)
-            if (prebuiltImage != null) {
-                return produceStages(ctx, null, prebuiltImage)
-            } else if (impl.language in ["Java", "Scala", "Kotlin"]) {
+            if (impl.language in ["Java", "Scala", "Kotlin"]) {
                 def stage1 = new BuildDockerJVMSDKPerformer(impl.language.toLowerCase(), impl.version())
                 imageName = stage1.imageName
                 return produceStages(ctx, stage1, stage1.getImageName())
@@ -95,7 +88,10 @@ class InitialiseSDKPerformer extends Stage {
     List<Stage> produceStages(StageContext ctx, Stage stage1, String imageName){
         List<Stage> stages = []
 
-        if (!ctx.skipPerformerDockerBuild() && stage1 != null) {
+        if (stage1 == null) {
+            stages.add(new PullDockerImagePerformer(imageName))
+        }
+        else if (!ctx.skipPerformerDockerBuild()) {
             stages.add(stage1)
         }
 

--- a/src/com/couchbase/perf/sdk/stages/PrebuiltPerformerImage.groovy
+++ b/src/com/couchbase/perf/sdk/stages/PrebuiltPerformerImage.groovy
@@ -30,11 +30,11 @@ class PrebuiltPerformerImage {
     }
 
     static String tag(Implementation impl) {
+        if (impl.isGerrit()) {
+            throw new IllegalArgumentException("Prebuilt FIT performer images are not supported for Gerrit changesets (${impl.version()}). Disable usePrebuiltImages to build from source.")
+        }
         if (impl.isMain() || impl.isSnapshot) {
             return "main"
-        }
-        if (impl.isGerrit()) {
-            return impl.version().replaceAll("[^A-Za-z0-9.]", "-")
         }
         return impl.version()
     }

--- a/src/com/couchbase/perf/sdk/stages/PrebuiltPerformerImage.groovy
+++ b/src/com/couchbase/perf/sdk/stages/PrebuiltPerformerImage.groovy
@@ -1,0 +1,41 @@
+package com.couchbase.perf.sdk.stages
+
+import com.couchbase.perf.shared.config.PerfConfig.Implementation
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class PrebuiltPerformerImage {
+    private static final String REGISTRY = "ghcr.io"
+    private static final String ORG = "couchbase"
+
+    private static final Map<String, String> SDK_NAMES = [
+            "Java"  : "java",
+            "Scala" : "scala",
+            "Kotlin": "kotlin",
+            ".NET"  : "dotnet",
+            "Go"    : "go",
+            "Python": "python",
+            "Node"  : "node",
+            "C++"   : "cpp",
+            "Ruby"  : "ruby",
+            "Rust"  : "rust",
+    ]
+
+    static String imageName(Implementation impl) {
+        String sdk = SDK_NAMES.get(impl.language)
+        if (sdk == null) {
+            throw new IllegalArgumentException("No prebuilt FIT performer image is known for SDK '${impl.language}'. Known SDKs: ${SDK_NAMES.keySet().join(", ")}.")
+        }
+        return "${REGISTRY}/${ORG}/${sdk}-fit-performer:${tag(impl)}"
+    }
+
+    static String tag(Implementation impl) {
+        if (impl.isMain() || impl.isSnapshot) {
+            return "main"
+        }
+        if (impl.isGerrit()) {
+            return impl.version().replaceAll("[^A-Za-z0-9.]", "-")
+        }
+        return impl.version()
+    }
+}

--- a/src/com/couchbase/perf/sdk/stages/PullDockerImagePerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/PullDockerImagePerformer.groovy
@@ -1,0 +1,48 @@
+package com.couchbase.perf.sdk.stages
+
+import com.couchbase.context.StageContext
+import com.couchbase.stages.Stage
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class PullDockerImagePerformer extends Stage {
+    private static final String REGISTRY = "ghcr.io"
+
+    private final String imageName
+
+    PullDockerImagePerformer(String imageName) {
+        this.imageName = imageName
+    }
+
+    @Override
+    String name() {
+        return "Pull docker image ${imageName}"
+    }
+
+    @Override
+    void executeImpl(StageContext ctx) {
+        String token = System.getenv("GITHUB_TOKEN")
+        if (token == null || token.trim().isEmpty()) {
+            throw new RuntimeException("GITHUB_TOKEN environment variable is required to pull prebuilt performer images from ${REGISTRY} (needs read:packages scope).")
+        }
+        String username = System.getenv("GITHUB_ACTOR")
+        if (username == null || username.trim().isEmpty()) {
+            username = "couchbase"
+        }
+        login(ctx, REGISTRY, username, token)
+        ctx.env.execute("docker pull ${imageName}", false, true, true)
+    }
+
+    private static void login(StageContext ctx, String registry, String username, String token) {
+        ctx.env.log("Logging in to ${registry} as ${username}")
+        def pb = new ProcessBuilder("docker", "login", registry, "-u", username, "--password-stdin")
+        pb.redirectErrorStream(true)
+        Process proc = pb.start()
+        proc.outputStream.withWriter("UTF-8") { it.write(token) }
+        String output = proc.inputStream.getText("UTF-8")
+        int code = proc.waitFor()
+        if (code != 0) {
+            throw new RuntimeException("docker login to ${registry} failed with exit code ${code}: ${output}")
+        }
+    }
+}

--- a/src/com/couchbase/perf/sdk/stages/StartDockerImageCppSDKPerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/StartDockerImageCppSDKPerformer.groovy
@@ -27,8 +27,9 @@ class StartDockerImageCppSDKPerformer extends Stage {
 
     @Override
     void executeImpl(StageContext ctx) {
+        String logLevel = System.getenv("FIT_LOG_LEVEL") ?: "info"
         // -d so this will run in background
-        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -p $port:8060 --name ${containerName} $imageName",
+        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -e FIT_LOG_LEVEL=${logLevel} -p $port:8060 --name ${containerName} $imageName",
                 false, false, true)
         // Stream the logs in the background
         ctx.env.execute("docker logs --follow ${containerName}", false, false, true, true)

--- a/src/com/couchbase/perf/sdk/stages/StartDockerImageCppSDKPerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/StartDockerImageCppSDKPerformer.groovy
@@ -27,9 +27,9 @@ class StartDockerImageCppSDKPerformer extends Stage {
 
     @Override
     void executeImpl(StageContext ctx) {
-        String logLevel = System.getenv("FIT_LOG_LEVEL") ?: "info"
+        String logLevel = System.getenv("LOG_LEVEL") ?: "info"
         // -d so this will run in background
-        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -e FIT_LOG_LEVEL=${logLevel} -p $port:8060 --name ${containerName} $imageName",
+        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -e LOG_LEVEL=${logLevel} -p $port:8060 --name ${containerName} $imageName",
                 false, false, true)
         // Stream the logs in the background
         ctx.env.execute("docker logs --follow ${containerName}", false, false, true, true)

--- a/src/com/couchbase/perf/sdk/stages/StartDockerImagePerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/StartDockerImagePerformer.groovy
@@ -26,8 +26,9 @@ class StartDockerImagePerformer extends Stage {
 
     @Override
     void executeImpl(StageContext ctx) {
+        String logLevel = System.getenv("FIT_LOG_LEVEL") ?: "info"
         // -d so this will run in background
-        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -p $port:8060 --name ${containerName} $imageName",
+        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -e FIT_LOG_LEVEL=${logLevel} -p $port:8060 --name ${containerName} $imageName",
                 false, false, true)
         // Stream the logs in the background
         ctx.env.execute("docker logs --follow ${containerName}", false, false, true, true)

--- a/src/com/couchbase/perf/sdk/stages/StartDockerImagePerformer.groovy
+++ b/src/com/couchbase/perf/sdk/stages/StartDockerImagePerformer.groovy
@@ -26,9 +26,9 @@ class StartDockerImagePerformer extends Stage {
 
     @Override
     void executeImpl(StageContext ctx) {
-        String logLevel = System.getenv("FIT_LOG_LEVEL") ?: "info"
+        String logLevel = System.getenv("LOG_LEVEL") ?: "info"
         // -d so this will run in background
-        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -e FIT_LOG_LEVEL=${logLevel} -p $port:8060 --name ${containerName} $imageName",
+        ctx.env.execute("${ctx.env.isWindows() || ctx.env.isMacOS() ? "" : "timeout 24h "}docker run --rm -d --network perf -e LOG_LEVEL=${logLevel} -p $port:8060 --name ${containerName} $imageName",
                 false, false, true)
         // Stream the logs in the background
         ctx.env.execute("docker logs --follow ${containerName}", false, false, true, true)


### PR DESCRIPTION
New opt-in usePrebuiltImages flag pulls each SDK's performer image from ghcr.io instead of building it from source, and LOG_LEVEL is now passed into running containers.